### PR TITLE
GH-280: fix lambda parameter type annotations in nested lambdas

### DIFF
--- a/lambda_compiler/examples/lambda_captures.tl
+++ b/lambda_compiler/examples/lambda_captures.tl
@@ -1,1 +1,1 @@
-() => {(a, b) => () => [b, a]}("bda", "lam")()
+() => {(a: String, b: String) => () => [b, a]}("bda", "lam")()

--- a/lambda_compiler/examples/lambda_parameters.tl
+++ b/lambda_compiler/examples/lambda_parameters.tl
@@ -1,1 +1,1 @@
-() => {(a, b) => [b, a]}("bda", "lam")
+() => {(a: String, b: String) => [b, a]}("bda", "lam")

--- a/lambda_compiler/examples/local_variables.tl
+++ b/lambda_compiler/examples/local_variables.tl
@@ -1,5 +1,10 @@
 () => {
     let a = "bda"
     let b = "lam"
-    [b, a]
+    let f = (x: String, y: String) => {
+        let first = y
+        let second = x
+        [first, second]
+    }
+    f(a, b)
 }

--- a/lambda_compiler/src/ast.rs
+++ b/lambda_compiler/src/ast.rs
@@ -25,7 +25,7 @@ impl LambdaParameter {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum Expression {
     Identifier(Name, SourceLocation),
-    StringLiteral(String),
+    StringLiteral(String, SourceLocation),
     Apply {
         callee: Box<Expression>,
         arguments: Vec<Expression>,
@@ -48,7 +48,7 @@ impl Expression {
     pub fn source_location(&self) -> SourceLocation {
         match self {
             Expression::Identifier(_, location) => *location,
-            Expression::StringLiteral(_) => todo!(),
+            Expression::StringLiteral(_, location) => *location,
             Expression::Apply { callee, .. } => callee.source_location(),
             Expression::Lambda { body, .. } => body.source_location(),
             Expression::ConstructTree(_) => todo!(),

--- a/lambda_compiler/src/format.rs
+++ b/lambda_compiler/src/format.rs
@@ -78,7 +78,9 @@ where
 {
     match expression {
         Expression::Identifier(name, _source_location) => write!(writer, "{}", &name.key),
-        Expression::StringLiteral(content) => format_string_literal(content, writer),
+        Expression::StringLiteral(content, _source_location) => {
+            format_string_literal(content, writer)
+        }
         Expression::Apply { callee, arguments } => {
             format_apply(callee, arguments, indentation_level, writer)
         }

--- a/lambda_compiler/src/format_test.rs
+++ b/lambda_compiler/src/format_test.rs
@@ -8,6 +8,7 @@ use lambda::name::{Name, NamespaceId};
 const TEST_NAMESPACE: NamespaceId =
     NamespaceId([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 const IRRELEVANT_INDENTATION_LEVEL: usize = 23;
+const IRRELEVANT_SOURCE_LOCATION: SourceLocation = SourceLocation { line: 1, column: 2 };
 
 #[test]
 fn test_format_identifier() {
@@ -15,8 +16,7 @@ fn test_format_identifier() {
     format_expression(
         &Expression::Identifier(
             Name::new(TEST_NAMESPACE, "id123".to_string()),
-            // location doesn't matter for this test
-            SourceLocation { line: 1, column: 2 },
+            IRRELEVANT_SOURCE_LOCATION,
         ),
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
@@ -29,7 +29,7 @@ fn test_format_identifier() {
 fn test_format_string_literal_alphanumeric() {
     let mut formatted = String::new();
     format_expression(
-        &Expression::StringLiteral(r#"abc123"#.to_string()),
+        &Expression::StringLiteral(r#"abc123"#.to_string(), IRRELEVANT_SOURCE_LOCATION),
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
     )
@@ -41,7 +41,7 @@ fn test_format_string_literal_alphanumeric() {
 fn test_format_string_literal_quotes_and_backslash() {
     let mut formatted = String::new();
     format_expression(
-        &Expression::StringLiteral(r#""'\"#.to_string()),
+        &Expression::StringLiteral(r#""'\"#.to_string(), IRRELEVANT_SOURCE_LOCATION),
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
     )
@@ -53,7 +53,7 @@ fn test_format_string_literal_quotes_and_backslash() {
 fn test_format_string_literal_whitespace() {
     let mut formatted = String::new();
     format_expression(
-        &Expression::StringLiteral("\n\r\t".to_string()),
+        &Expression::StringLiteral("\n\r\t".to_string(), IRRELEVANT_SOURCE_LOCATION),
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
     )
@@ -68,8 +68,7 @@ fn test_format_apply_0_arguments() {
         &Expression::Apply {
             callee: Box::new(Expression::Identifier(
                 Name::new(TEST_NAMESPACE, "f".to_string()),
-                // location doesn't matter for this test
-                SourceLocation { line: 1, column: 2 },
+                IRRELEVANT_SOURCE_LOCATION,
             )),
             arguments: Vec::new(),
         },
@@ -87,10 +86,12 @@ fn test_format_apply_1_argument() {
         &Expression::Apply {
             callee: Box::new(Expression::Identifier(
                 Name::new(TEST_NAMESPACE, "f".to_string()),
-                // location doesn't matter for this test
-                SourceLocation { line: 1, column: 2 },
+                IRRELEVANT_SOURCE_LOCATION,
             )),
-            arguments: vec![Expression::StringLiteral("test".to_string())],
+            arguments: vec![Expression::StringLiteral(
+                "test".to_string(),
+                IRRELEVANT_SOURCE_LOCATION,
+            )],
         },
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
@@ -106,12 +107,11 @@ fn test_format_apply_2_arguments() {
         &Expression::Apply {
             callee: Box::new(Expression::Identifier(
                 Name::new(TEST_NAMESPACE, "f".to_string()),
-                // location doesn't matter for this test
-                SourceLocation { line: 1, column: 2 },
+                IRRELEVANT_SOURCE_LOCATION,
             )),
             arguments: vec![
-                Expression::StringLiteral("test".to_string()),
-                Expression::StringLiteral("123".to_string()),
+                Expression::StringLiteral("test".to_string(), IRRELEVANT_SOURCE_LOCATION),
+                Expression::StringLiteral("123".to_string(), IRRELEVANT_SOURCE_LOCATION),
             ],
         },
         IRRELEVANT_INDENTATION_LEVEL,

--- a/lambda_compiler/src/parsing.rs
+++ b/lambda_compiler/src/parsing.rs
@@ -334,7 +334,10 @@ fn parse_expression_start<'t>(
             TokenContent::Colon => todo!(),
             TokenContent::Quotes(content) => {
                 pop_next_non_whitespace_token(tokens);
-                Ok(ast::Expression::StringLiteral(content.clone()))
+                Ok(ast::Expression::StringLiteral(
+                    content.clone(),
+                    non_whitespace.location,
+                ))
             }
             TokenContent::FatArrow => Err(ParserError::new(
                 "Expected expression, found fat arrow.".to_string(),

--- a/lambda_compiler/src/type_checking.rs
+++ b/lambda_compiler/src/type_checking.rs
@@ -669,8 +669,22 @@ pub async fn check_types(
             ast::Expression::Identifier(name, location) => {
                 Ok(environment_builder.read(name, location))
             }
-            ast::Expression::StringLiteral(value) => {
-                let compile_time_value = DeepTree::try_from_string(value).unwrap(/*TODO*/);
+            ast::Expression::StringLiteral(value, source_location) => {
+                let compile_time_value = match DeepTree::try_from_string(value) {
+                    Some(tree) => tree,
+                    None => {
+                        return Ok((
+                            CompilerOutput::new(
+                                None,
+                                vec![CompilerError::new(
+                                    format!("String literal is too long"),
+                                    *source_location,
+                                )],
+                            ),
+                            None,
+                        ))
+                    }
+                };
                 Ok((
                     CompilerOutput::new(
                         Some(TypedExpression::new(

--- a/lambda_compiler/src/type_checking.rs
+++ b/lambda_compiler/src/type_checking.rs
@@ -595,7 +595,7 @@ pub async fn check_lambda(
                     return_type: Box::new(body_checked.type_),
                 }),
             )),
-            errors: errors,
+            errors,
         }),
         None => Ok(CompilerOutput::new(None, errors)),
     }
@@ -667,7 +667,7 @@ pub async fn check_types(
                             CompilerOutput::new(
                                 None,
                                 vec![CompilerError::new(
-                                    format!("String literal is too long"),
+                                    "String literal is too long".to_string(),
                                     *source_location,
                                 )],
                             ),

--- a/lambda_compiler/src/type_checking.rs
+++ b/lambda_compiler/src/type_checking.rs
@@ -601,16 +601,6 @@ pub async fn check_lambda(
     }
 }
 
-pub async fn check_braces(
-    expression: &[ast::Expression],
-    environment_builder: &mut EnvironmentBuilder,
-) -> Result<(CompilerOutput, Option<DeepTree>), StoreError> {
-    if expression.len() != 1 {
-        todo!()
-    }
-    check_types(&expression[0], environment_builder).await
-}
-
 pub async fn check_let(
     name: &Name,
     location: &SourceLocation,

--- a/lambda_compiler/src/type_checking_test.rs
+++ b/lambda_compiler/src/type_checking_test.rs
@@ -750,7 +750,7 @@ async fn test_string_literal_too_long() {
     let expected = CompilerOutput::new(
         None,
         vec![crate::compilation::CompilerError::new(
-            format!("String literal is too long"),
+            "String literal is too long".to_string(),
             SourceLocation { line: 3, column: 3 },
         )],
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced type checking to propagate compile-time known values alongside type information, improving optimisation and analysis.
  - Updated environment reading and lambda parameter checking to better handle explicit type annotations and compile-time values.
  - Modified AST and parsing to include source location metadata for string literals, enabling improved error reporting and debugging.
- **Style**
  - Added explicit type annotations to lambda parameters in example files for improved clarity.
  - Introduced a local function to swap variables, demonstrating local variable usage.
- **Tests**
  - Added tests to verify error handling for invalid lambda parameter type annotations.
  - Added tests for handling undefined identifiers and overly long string literals.
  - Updated existing tests to reflect changes in type checking output, including constant folding of literals.
- **Documentation**
  - Improved test code by consolidating repeated source location literals into a constant for clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->