### PR TITLE
GH-290: check argument count and types

### DIFF
--- a/lambda_compiler/examples/type_of.tl
+++ b/lambda_compiler/examples/type_of.tl
@@ -11,6 +11,6 @@
     }
     # Variables can hold types.
     let StringAlias = type_of("")
-    let call_function = (function: type_of(f), x: StringAlias, y: type_of(f("", ""))) => function(x, y)
+    let call_function = (function: type_of(f), x: StringAlias, y: String) => function(x, y)
     call_function(f, a, b)
 }

--- a/lambda_compiler/src/ast.rs
+++ b/lambda_compiler/src/ast.rs
@@ -34,7 +34,7 @@ pub enum Expression {
         parameters: Vec<LambdaParameter>,
         body: Box<Expression>,
     },
-    ConstructTree(Vec<Expression>),
+    ConstructTree(Vec<Expression>, SourceLocation),
     Braces(Box<Expression>),
     Let {
         name: Name,
@@ -53,7 +53,7 @@ impl Expression {
             Expression::StringLiteral(_, source_location) => *source_location,
             Expression::Apply { callee, .. } => callee.source_location(),
             Expression::Lambda { body, .. } => body.source_location(),
-            Expression::ConstructTree(_) => todo!(),
+            Expression::ConstructTree(_, source_location) => *source_location,
             Expression::Braces(expression) => expression.source_location(),
             Expression::Let {
                 name: _,

--- a/lambda_compiler/src/format.rs
+++ b/lambda_compiler/src/format.rs
@@ -113,7 +113,7 @@ where
         Expression::Lambda { parameters, body } => {
             format_lambda(parameters, body, indentation_level, writer)
         }
-        Expression::ConstructTree(children) => {
+        Expression::ConstructTree(children, _) => {
             write!(writer, "[")?;
             for (index, child) in children.iter().enumerate() {
                 if index > 0 {

--- a/lambda_compiler/src/format_test.rs
+++ b/lambda_compiler/src/format_test.rs
@@ -228,7 +228,7 @@ fn test_format_lambda_type_annotation() {
 fn test_format_construct_tree_0_children() {
     let mut formatted = String::new();
     format_expression(
-        &Expression::ConstructTree(vec![]),
+        &Expression::ConstructTree(vec![], IRRELEVANT_SOURCE_LOCATION),
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
     )
@@ -240,11 +240,14 @@ fn test_format_construct_tree_0_children() {
 fn test_format_construct_tree_1_child() {
     let mut formatted = String::new();
     format_expression(
-        &Expression::ConstructTree(vec![Expression::Identifier(
-            Name::new(TEST_NAMESPACE, "a".to_string()),
-            // location doesn't matter for this test
-            SourceLocation { line: 0, column: 0 },
-        )]),
+        &Expression::ConstructTree(
+            vec![Expression::Identifier(
+                Name::new(TEST_NAMESPACE, "a".to_string()),
+                // location doesn't matter for this test
+                SourceLocation { line: 0, column: 0 },
+            )],
+            IRRELEVANT_SOURCE_LOCATION,
+        ),
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
     )
@@ -256,18 +259,21 @@ fn test_format_construct_tree_1_child() {
 fn test_format_construct_tree_2_children() {
     let mut formatted = String::new();
     format_expression(
-        &Expression::ConstructTree(vec![
-            Expression::Identifier(
-                Name::new(TEST_NAMESPACE, "a".to_string()),
-                // location doesn't matter for this test
-                SourceLocation { line: 0, column: 0 },
-            ),
-            Expression::Identifier(
-                Name::new(TEST_NAMESPACE, "b".to_string()),
-                // location doesn't matter for this test
-                SourceLocation { line: 0, column: 0 },
-            ),
-        ]),
+        &Expression::ConstructTree(
+            vec![
+                Expression::Identifier(
+                    Name::new(TEST_NAMESPACE, "a".to_string()),
+                    // location doesn't matter for this test
+                    SourceLocation { line: 0, column: 0 },
+                ),
+                Expression::Identifier(
+                    Name::new(TEST_NAMESPACE, "b".to_string()),
+                    // location doesn't matter for this test
+                    SourceLocation { line: 0, column: 0 },
+                ),
+            ],
+            IRRELEVANT_SOURCE_LOCATION,
+        ),
         IRRELEVANT_INDENTATION_LEVEL,
         &mut formatted,
     )

--- a/lambda_compiler/src/parsing.rs
+++ b/lambda_compiler/src/parsing.rs
@@ -262,6 +262,7 @@ fn skip_right_bracket(tokens: &mut std::iter::Peekable<std::slice::Iter<'_, Toke
 fn parse_tree_construction(
     tokens: &mut std::iter::Peekable<std::slice::Iter<'_, Token>>,
     local_namespace: &NamespaceId,
+    location: &SourceLocation,
 ) -> ParserResult<ast::Expression> {
     let mut elements = Vec::new();
     loop {
@@ -277,7 +278,7 @@ fn parse_tree_construction(
         let element = parse_expression(tokens, local_namespace)?;
         elements.push(element);
     }
-    Ok(ast::Expression::ConstructTree(elements))
+    Ok(ast::Expression::ConstructTree(elements, *location))
 }
 
 fn parse_braces(
@@ -385,7 +386,7 @@ fn parse_expression_start<'t>(
             )),
             TokenContent::LeftBracket => {
                 pop_next_non_whitespace_token(tokens);
-                parse_tree_construction(tokens, local_namespace)
+                parse_tree_construction(tokens, local_namespace, &non_whitespace.location)
             }
             TokenContent::RightBracket => Err(ParserError::new(
                 "Expected expression, found right bracket.".to_string(),

--- a/lambda_compiler/src/parsing_test.rs
+++ b/lambda_compiler/src/parsing_test.rs
@@ -294,7 +294,13 @@ fn test_parse_missing_parameter_type() {
 #[test_log::test]
 fn test_parse_tree_construction_0_children() {
     for source in &["[]", " []", "[ ]", " [] ", "[  ]", "[ ] "] {
-        let expected = ast::Expression::ConstructTree(vec![]);
+        let expected = ast::Expression::ConstructTree(
+            vec![],
+            SourceLocation {
+                line: 0,
+                column: source.find("[").unwrap() as u64,
+            },
+        );
         test_wellformed_parsing(source, expected);
     }
 }
@@ -312,7 +318,13 @@ fn test_parse_tree_construction_1_child() {
                 column: source.find("a").unwrap() as u64,
             },
         );
-        let expected = ast::Expression::ConstructTree(vec![a]);
+        let expected = ast::Expression::ConstructTree(
+            vec![a],
+            SourceLocation {
+                line: 0,
+                column: source.find("[").unwrap() as u64,
+            },
+        );
         test_wellformed_parsing(source, expected);
     }
 }
@@ -344,7 +356,13 @@ fn test_parse_tree_construction_2_children() {
                 column: source.find("b").unwrap() as u64,
             },
         );
-        let expected = ast::Expression::ConstructTree(vec![a, b]);
+        let expected = ast::Expression::ConstructTree(
+            vec![a, b],
+            SourceLocation {
+                line: 0,
+                column: source.find("[").unwrap() as u64,
+            },
+        );
         test_wellformed_parsing(source, expected);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved type checking for function arguments, including detailed error messages when argument types do not match parameter types.
- **Bug Fixes**
	- Source location information is now accurately tracked for tree construction expressions, providing more precise error reporting.
- **Tests**
	- Added new tests to verify type errors are correctly reported for argument type mismatches and argument count mismatches.
	- Updated existing tests to include source location data for tree construction expressions.
- **Enhancements**
	- Explicit source location tracking added to tree construction expressions for improved debugging.
	- Type annotations refined in example functions to use explicit types instead of inferred dynamic types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->