### PR TITLE
Update Rust toolchain to 2025-10-01

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-09-08"
+channel = "nightly-2025-10-01"
 components = ["rustfmt", "clippy", "cargo", "rustc", "llvm-tools-preview"]
 targets = ["x86_64-pc-windows-msvc", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
 profile = "minimal"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the build/development toolchain to a newer Rust nightly (2025-10-01), aligning CI and local builds for consistency and future compatibility.
  * No user-facing changes, UI adjustments, or performance impact expected.
  * Reduces build variability and improves developer experience; if you build from source, ensure your environment picks up the updated toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->