### PR TITLE
Prolly tree polishing

### DIFF
--- a/astraea/src/storage_test.rs
+++ b/astraea/src/storage_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     storage::{CommitChanges, LoadRoot, LoadTree, SQLiteStorage, StoreTree, UpdateRoot},
-    tree::{BlobDigest, HashedTree, Tree, TreeBlob},
+    tree::{BlobDigest, HashedTree, Tree, TreeBlob, TreeChildren},
 };
 use bytes::Bytes;
 use pretty_assertions::assert_eq;
@@ -80,7 +80,7 @@ async fn test_store_blob() {
     let storage = SQLiteStorage::from(connection).unwrap();
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(Bytes::from("test 123")).unwrap(),
-        vec![],
+        TreeChildren::empty(),
     ));
     let reference = storage
         .store_tree(&HashedTree::from(tree.clone()))
@@ -108,7 +108,7 @@ async fn test_store_reference() {
     let referenced_digest = BlobDigest::hash(b"ref");
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(Bytes::from("test 123")).unwrap(),
-        vec![referenced_digest],
+        TreeChildren::try_from(vec![referenced_digest]).unwrap(),
     ));
     let reference = storage
         .store_tree(&HashedTree::from(tree.clone()))
@@ -139,7 +139,7 @@ async fn test_store_two_references() {
         .collect();
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(Bytes::from("test 123")).unwrap(),
-        referenced_digests,
+        TreeChildren::try_from(referenced_digests).unwrap(),
     ));
     let reference = storage
         .store_tree(&HashedTree::from(tree.clone()))
@@ -170,7 +170,7 @@ async fn test_store_three_references() {
         .collect();
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(Bytes::from("test 123")).unwrap(),
-        referenced_digests,
+        TreeChildren::try_from(referenced_digests).unwrap(),
     ));
     let reference = storage
         .store_tree(&HashedTree::from(tree.clone()))
@@ -212,7 +212,7 @@ async fn test_update_root() {
     let reference_2 = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::try_from(Bytes::from("test 123")).unwrap(),
-            vec![],
+            TreeChildren::empty(),
         ))))
         .await
         .unwrap();
@@ -260,7 +260,7 @@ async fn test_compression_compressible_data() {
     let compressible_data = "A".repeat(1000);
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(Bytes::from(compressible_data.clone())).unwrap(),
-        vec![],
+        TreeChildren::empty(),
     ));
     let reference = storage
         .store_tree(&HashedTree::from(tree.clone()))
@@ -290,7 +290,7 @@ async fn test_compression_uncompressible_data() {
     let uncompressible_data: Vec<u8> = (0..100).map(|i| (i * 7 + 13) as u8).collect();
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(Bytes::from(uncompressible_data.clone())).unwrap(),
-        vec![],
+        TreeChildren::empty(),
     ));
     let reference = storage
         .store_tree(&HashedTree::from(tree.clone()))
@@ -326,7 +326,7 @@ async fn test_compression_large_blob() {
 
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(Bytes::from(large_data.clone())).unwrap(),
-        vec![],
+        TreeChildren::empty(),
     ));
     let reference = storage
         .store_tree(&HashedTree::from(tree.clone()))

--- a/astraea/src/tree_tests.rs
+++ b/astraea/src/tree_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::tree::{
-    calculate_reference, BlobDigest, HashedTree, ReferenceIndex, Tree, TreeBlob,
+    calculate_reference, BlobDigest, HashedTree, ReferenceIndex, Tree, TreeBlob, TreeChildren,
     TreeDeserializationError, TreeSerializationError, TREE_BLOB_MAX_LENGTH,
 };
 use pretty_assertions::assert_eq;
@@ -106,7 +106,7 @@ fn test_calculate_reference_blob_no_references_0() {
 fn test_calculate_reference_blob_yes_references_0() {
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(bytes::Bytes::from("Hello, world!")).unwrap(),
-        Vec::new(),
+        TreeChildren::empty(),
     ));
     let reference = calculate_reference(&tree);
     assert_eq!(
@@ -119,7 +119,7 @@ fn test_calculate_reference_blob_yes_references_0() {
 fn test_calculate_reference_blob_no_references_1() {
     let tree = Arc::new(Tree::new(
         TreeBlob::empty(),
-        vec![BlobDigest(([0u8; 32], [0u8; 32]))],
+        TreeChildren::try_from(vec![BlobDigest(([0u8; 32], [0u8; 32]))]).unwrap(),
     ));
     let reference = calculate_reference(&tree);
     assert_eq!(
@@ -132,7 +132,7 @@ fn test_calculate_reference_blob_no_references_1() {
 fn test_calculate_reference_blob_yes_references_1() {
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(bytes::Bytes::from("Hello, world!")).unwrap(),
-        vec![BlobDigest(([0u8; 32], [0u8; 32]))],
+        TreeChildren::try_from(vec![BlobDigest(([0u8; 32], [0u8; 32]))]).unwrap(),
     ));
     let reference = calculate_reference(&tree);
     assert_eq!(
@@ -145,10 +145,11 @@ fn test_calculate_reference_blob_yes_references_1() {
 fn test_calculate_reference_blob_no_references_2() {
     let tree = Arc::new(Tree::new(
         TreeBlob::empty(),
-        vec![
+        TreeChildren::try_from(vec![
             BlobDigest(([0u8; 32], [0u8; 32])),
             BlobDigest(([1u8; 32], [1u8; 32])),
-        ],
+        ])
+        .unwrap(),
     ));
     let reference = calculate_reference(&tree);
     assert_eq!(
@@ -161,10 +162,11 @@ fn test_calculate_reference_blob_no_references_2() {
 fn test_calculate_reference_blob_yes_references_2() {
     let tree = Arc::new(Tree::new(
         TreeBlob::try_from(bytes::Bytes::from("Hello, world!")).unwrap(),
-        vec![
+        TreeChildren::try_from(vec![
             BlobDigest(([0u8; 32], [0u8; 32])),
             BlobDigest(([1u8; 32], [1u8; 32])),
-        ],
+        ])
+        .unwrap(),
     ));
     let reference = calculate_reference(&tree);
     assert_eq!(

--- a/dogbox/dogbox_tree_editor/src/tests2.rs
+++ b/dogbox/dogbox_tree_editor/src/tests2.rs
@@ -5,7 +5,7 @@ use crate::{
     StreakDirection, TreeEditor,
 };
 use astraea::storage::{DelayedHashedTree, InMemoryTreeStorage, LoadTree, StoreError, StoreTree};
-use astraea::tree::calculate_reference;
+use astraea::tree::{calculate_reference, TreeChildren};
 use astraea::{
     storage::LoadStoreTree,
     tree::{BlobDigest, HashedTree, Tree, TreeBlob, TREE_BLOB_MAX_LENGTH},
@@ -869,7 +869,7 @@ async fn open_file_content_buffer_write_fill_zero_block() {
     let data = Vec::new();
     let last_known_digest = calculate_reference(&Tree::new(
         TreeBlob::try_from(bytes::Bytes::copy_from_slice(&data[..])).unwrap(),
-        vec![],
+        TreeChildren::empty(),
     ));
     let last_known_digest_file_size = data.len();
     let mut buffer = OpenFileContentBuffer::from_data(
@@ -944,7 +944,7 @@ async fn open_file_content_buffer_overwrite_full_block() {
     assert_ne!(&original_data[..], &write_data[..]);
     let last_known_digest = calculate_reference(&Tree::new(
         TreeBlob::try_from(bytes::Bytes::copy_from_slice(&original_data)).unwrap(),
-        vec![],
+        TreeChildren::empty(),
     ));
     assert_eq!(
         &BlobDigest::parse_hex_string(concat!(
@@ -973,7 +973,7 @@ async fn open_file_content_buffer_overwrite_full_block() {
         blocks: vec![OpenFileContentBlock::Loaded(
             crate::LoadedBlock::KnownDigest(HashedTree::from(Arc::new(Tree::new(
                 TreeBlob::try_from(write_data.clone()).unwrap(),
-                Vec::new(),
+                TreeChildren::empty(),
             )))),
         )],
         digest: crate::DigestStatus {
@@ -1032,7 +1032,7 @@ async fn open_file_content_buffer_store() {
     let data = Vec::new();
     let last_known_digest = calculate_reference(&Tree::new(
         TreeBlob::try_from(bytes::Bytes::copy_from_slice(&data[..])).unwrap(),
-        vec![],
+        TreeChildren::empty(),
     ));
     let last_known_digest_file_size = data.len();
     let mut buffer = OpenFileContentBuffer::from_data(
@@ -1058,7 +1058,7 @@ async fn open_file_content_buffer_store() {
             OpenFileContentBlock::NotLoaded(
                 calculate_reference(&Tree::new(
                     TreeBlob::try_from(bytes::Bytes::from(vec![0; TREE_BLOB_MAX_LENGTH])).unwrap(),
-                    vec![],
+                    TreeChildren::empty(),
                 )),
                 TREE_BLOB_MAX_LENGTH as u16,
             ),
@@ -1066,7 +1066,7 @@ async fn open_file_content_buffer_store() {
                 calculate_reference(&Tree::new(
                     TreeBlob::try_from(bytes::Bytes::copy_from_slice(write_data.as_bytes()))
                         .unwrap(),
-                    vec![],
+                    TreeChildren::empty(),
                 )),
                 write_data.len() as u16,
             ),

--- a/fuzz/fuzz_functions/src/prolly_tree_editable_node_remove.rs
+++ b/fuzz/fuzz_functions/src/prolly_tree_editable_node_remove.rs
@@ -109,7 +109,7 @@ async fn count_tree_node_count(root: &BlobDigest, storage: &InMemoryTreeStorage)
     let loaded = storage.load_tree(root).await.unwrap();
     let hashed = loaded.hash().unwrap();
     let mut sum = 1;
-    for child in hashed.tree().references() {
+    for child in hashed.tree().children().references() {
         let child_count = Box::pin(count_tree_node_count(child, storage)).await;
         sum += child_count;
     }

--- a/fuzz/fuzz_targets/write-read-large-files.rs
+++ b/fuzz/fuzz_targets/write-read-large-files.rs
@@ -8,7 +8,7 @@ fn main() {
 
 use astraea::{
     storage::{InMemoryTreeStorage, StoreTree},
-    tree::{HashedTree, Tree, TreeBlob, TREE_BLOB_MAX_LENGTH},
+    tree::{HashedTree, Tree, TreeBlob, TreeChildren, TREE_BLOB_MAX_LENGTH},
 };
 use dogbox_tree_editor::{OpenFileContentBuffer, OptimizedWriteBuffer};
 use libfuzzer_sys::{fuzz_target, Corpus};
@@ -154,7 +154,7 @@ fn run_generated_test(test: GeneratedTest) -> Corpus {
             let last_known_digest = storage
                 .store_tree(&HashedTree::from(Arc::new(Tree::new(
                     TreeBlob::empty(),
-                    Vec::new(),
+                    TreeChildren::empty(),
                 ))))
                 .await
                 .unwrap();

--- a/lambda/src/effect_tests.rs
+++ b/lambda/src/effect_tests.rs
@@ -44,8 +44,8 @@ async fn effect() {
             .print(&mut program_as_string, 0)
             .unwrap();
         assert_eq!(concat!(
-            "$env={literal(DeepTree { blob: TreeBlob { content: b\"\" }, references: [] })}($arg) =>\n",
-            "  [literal(DeepTree { blob: TreeBlob { content: b\"\" }, references: [DeepTree { blob: TreeBlob { content: b\"Hello, \" }, references: [] }] }), $env={literal(DeepTree { blob: TreeBlob { content: b\"\" }, references: [] })}($arg) =>\n",
+            "$env={literal(DeepTree { blob: TreeBlob { content: b\"\" }, children: DeepTreeChildren { references: [] } })}($arg) =>\n",
+            "  [literal(DeepTree { blob: TreeBlob { content: b\"\" }, children: DeepTreeChildren { references: [DeepTree { blob: TreeBlob { content: b\"Hello, \" }, children: DeepTreeChildren { references: [] } }] } }), $env={literal(DeepTree { blob: TreeBlob { content: b\"\" }, children: DeepTreeChildren { references: [] } })}($arg) =>\n",
             "    [$env, ], ]"),
             program_as_string.as_str());
     }

--- a/lambda/src/expressions_tests.rs
+++ b/lambda/src/expressions_tests.rs
@@ -44,8 +44,8 @@ fn print_all_expression_types() {
     apply.print(&mut writer, 0).unwrap();
     assert_eq!(
         concat!(
-            "$env={literal(DeepTree { blob: TreeBlob { content: b\"Hello, world!\" }, references: [] })}($arg) =>\n",
-            "  [$arg, $env, ](literal(DeepTree { blob: TreeBlob { content: b\"2\" }, references: [] }))"),
+            "$env={literal(DeepTree { blob: TreeBlob { content: b\"Hello, world!\" }, children: DeepTreeChildren { references: [] } })}($arg) =>\n",
+            "  [$arg, $env, ](literal(DeepTree { blob: TreeBlob { content: b\"2\" }, children: DeepTreeChildren { references: [] } }))"),
         writer.as_str());
 }
 

--- a/lambda/src/hello_world_tests.rs
+++ b/lambda/src/hello_world_tests.rs
@@ -26,8 +26,8 @@ async fn hello_world() {
             .unwrap();
         assert_eq!(
             concat!(
-            "$env={literal(DeepTree { blob: TreeBlob { content: b\"\" }, references: [] })}($arg) =>\n",
-            "  literal(DeepTree { blob: TreeBlob { content: b\"\" }, references: [DeepTree { blob: TreeBlob { content: b\"Hello, world!\\n\" }, references: [] }] })"),
+            "$env={literal(DeepTree { blob: TreeBlob { content: b\"\" }, children: DeepTreeChildren { references: [] } })}($arg) =>\n",
+            "  literal(DeepTree { blob: TreeBlob { content: b\"\" }, children: DeepTreeChildren { references: [DeepTree { blob: TreeBlob { content: b\"Hello, world!\\n\" }, children: DeepTreeChildren { references: [] } }] } })"),
             program_as_string.as_str()
         );
     }

--- a/lambda/src/standard_library.rs
+++ b/lambda/src/standard_library.rs
@@ -1,4 +1,7 @@
-use astraea::{deep_tree::DeepTree, tree::TreeBlob};
+use astraea::{
+    deep_tree::{DeepTree, DeepTreeChildren},
+    tree::TreeBlob,
+};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConsoleOutput {
@@ -7,18 +10,21 @@ pub struct ConsoleOutput {
 
 impl ConsoleOutput {
     pub fn to_tree(&self) -> DeepTree {
-        DeepTree::new(TreeBlob::empty(), vec![self.message.clone()])
+        DeepTree::new(
+            TreeBlob::empty(),
+            DeepTreeChildren::try_from(vec![self.message.clone()]).expect("One child always fits"),
+        )
     }
 
     pub fn from_tree(tree: &DeepTree) -> Option<ConsoleOutput> {
         if !tree.blob().is_empty() {
             return None;
         }
-        if tree.references().len() != 1 {
+        if tree.children().references().len() != 1 {
             return None;
         }
         Some(ConsoleOutput {
-            message: tree.references()[0].clone(),
+            message: tree.children().references()[0].clone(),
         })
     }
 }

--- a/lambda_compiler/src/examples_test.rs
+++ b/lambda_compiler/src/examples_test.rs
@@ -5,7 +5,7 @@ use crate::{
 use astraea::{
     deep_tree::DeepTree,
     storage::{InMemoryTreeStorage, StoreTree},
-    tree::{BlobDigest, HashedTree, Tree, TreeBlob},
+    tree::{BlobDigest, HashedTree, Tree, TreeBlob, TreeChildren},
 };
 use lambda::{expressions::apply_evaluated_argument, name::NamespaceId};
 use pretty_assertions::assert_eq;
@@ -75,12 +75,13 @@ async fn test_hello_world() {
     let expected_result = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
-            vec![storage
+            TreeChildren::try_from(vec![storage
                 .store_tree(&HashedTree::from(Arc::new(
                     Tree::from_string("Hello, world!").unwrap(),
                 )))
                 .await
-                .unwrap()],
+                .unwrap()])
+            .unwrap(),
         ))))
         .await
         .unwrap();
@@ -94,7 +95,7 @@ async fn test_integers() {
     let expected_result = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
-            vec![
+            TreeChildren::try_from(vec![
                 storage
                     .store_tree(&HashedTree::from(Arc::new(Tree::from_postcard_integer(1))))
                     .await
@@ -109,7 +110,8 @@ async fn test_integers() {
                     .store_tree(&HashedTree::from(Arc::new(Tree::from_postcard_integer(0))))
                     .await
                     .unwrap(),
-            ],
+            ])
+            .unwrap(),
         ))))
         .await
         .unwrap();
@@ -123,7 +125,7 @@ async fn test_lambda_captures() {
     let expected_result = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
-            vec![
+            TreeChildren::try_from(vec![
                 storage
                     .store_tree(&HashedTree::from(Arc::new(
                         Tree::from_string("lam").unwrap(),
@@ -136,7 +138,8 @@ async fn test_lambda_captures() {
                     )))
                     .await
                     .unwrap(),
-            ],
+            ])
+            .unwrap(),
         ))))
         .await
         .unwrap();
@@ -150,7 +153,7 @@ async fn test_lambda_parameters() {
     let expected_result = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
-            vec![
+            TreeChildren::try_from(vec![
                 storage
                     .store_tree(&HashedTree::from(Arc::new(
                         Tree::from_string("lam").unwrap(),
@@ -163,7 +166,8 @@ async fn test_lambda_parameters() {
                     )))
                     .await
                     .unwrap(),
-            ],
+            ])
+            .unwrap(),
         ))))
         .await
         .unwrap();
@@ -177,7 +181,7 @@ async fn test_local_variables() {
     let expected_result = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
-            vec![
+            TreeChildren::try_from(vec![
                 storage
                     .store_tree(&HashedTree::from(Arc::new(
                         Tree::from_string("lam").unwrap(),
@@ -190,7 +194,8 @@ async fn test_local_variables() {
                     )))
                     .await
                     .unwrap(),
-            ],
+            ])
+            .unwrap(),
         ))))
         .await
         .unwrap();
@@ -204,7 +209,7 @@ async fn test_type_of() {
     let expected_result = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
-            vec![
+            TreeChildren::try_from(vec![
                 storage
                     .store_tree(&HashedTree::from(Arc::new(
                         Tree::from_string("lam").unwrap(),
@@ -217,7 +222,8 @@ async fn test_type_of() {
                     )))
                     .await
                     .unwrap(),
-            ],
+            ])
+            .unwrap(),
         ))))
         .await
         .unwrap();

--- a/lambda_compiler/src/type_checking_test.rs
+++ b/lambda_compiler/src/type_checking_test.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use astraea::{
-    deep_tree::DeepTree,
+    deep_tree::{DeepTree, DeepTreeChildren},
     tree::{TreeBlob, TREE_BLOB_MAX_LENGTH},
 };
 use lambda::{
@@ -570,7 +570,7 @@ async fn test_lambda_parameter_type_does_not_capture() {
                     })),
                 })),
                 argument: Arc::new(DeepExpression(lambda::expressions::Expression::Literal(
-                    type_to_deep_tree(&DeepType(GenericType::String)),
+                    type_to_deep_tree(&DeepType(GenericType::String)).unwrap(),
                 ))),
             }),
             DeepType(GenericType::Function {
@@ -1094,7 +1094,7 @@ async fn test_bool() {
     let output = check_types_with_default_globals(&input, TEST_SOURCE_NAMESPACE).await;
     let true_deep_tree = DeepTree::new(
         TreeBlob::try_from(bytes::Bytes::from_static(&[1u8])).expect("one byte will always fit"),
-        Vec::new(),
+        DeepTreeChildren::empty(),
     );
     let expected = CompilerOutput::new(
         Some(TypedExpression::new(
@@ -1123,7 +1123,7 @@ async fn test_bool() {
                             lambda::expressions::Expression::make_literal(DeepTree::new(
                                 TreeBlob::try_from(bytes::Bytes::from_static(&[0u8]))
                                     .expect("one byte will always fit"),
-                                Vec::new(),
+                                DeepTreeChildren::empty(),
                             )),
                         )),
                     ]),
@@ -1151,7 +1151,7 @@ async fn test_type_of() {
     let expected = CompilerOutput::new(
         Some(TypedExpression::new(
             DeepExpression(lambda::expressions::Expression::make_literal(
-                type_to_deep_tree(&DeepType(GenericType::String)),
+                type_to_deep_tree(&DeepType(GenericType::String)).unwrap(),
             )),
             DeepType(GenericType::Type),
         )),
@@ -1207,9 +1207,9 @@ async fn test_type_of_does_not_capture() {
                             vec![],
                         ))),
                         Arc::new(DeepExpression(
-                            lambda::expressions::Expression::make_literal(type_to_deep_tree(
-                                &DeepType(GenericType::Any),
-                            )),
+                            lambda::expressions::Expression::make_literal(
+                                type_to_deep_tree(&DeepType(GenericType::Any)).unwrap(),
+                            ),
                         )),
                     ),
                 )),

--- a/sorted_tree/src/sorted_tree_tests.rs
+++ b/sorted_tree/src/sorted_tree_tests.rs
@@ -1,5 +1,5 @@
 use crate::sorted_tree::{find, insert, load_node, new_tree, node_to_tree, Node, TreeReference};
-use astraea::tree::{BlobDigest, Tree, TreeBlob};
+use astraea::tree::{BlobDigest, Tree, TreeBlob, TreeChildren};
 use pretty_assertions::{assert_eq, assert_ne};
 use rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng};
 use std::collections::BTreeMap;
@@ -312,10 +312,10 @@ fn node_to_tree_without_child_references() {
     let mut node = Node::<u64, String>::new();
     node.insert(1, "A".to_string());
     node.insert(2, "B".to_string());
-    let tree = node_to_tree(&node, &bytes::Bytes::new());
+    let tree = node_to_tree(&node, &bytes::Bytes::new()).unwrap();
     let expected = Tree::new(
         TreeBlob::try_from(bytes::Bytes::from_static(b"\x02\x01\x01A\x02\x01B")).unwrap(),
-        Vec::new(),
+        TreeChildren::empty(),
     );
     assert_eq!(expected, tree);
 }
@@ -327,10 +327,10 @@ fn node_to_tree_with_child_references() {
     node.insert(1, TreeReference::new(reference_1));
     let reference_2 = BlobDigest::hash(&[32]);
     node.insert(2, TreeReference::new(reference_2));
-    let tree = node_to_tree(&node, &bytes::Bytes::new());
+    let tree = node_to_tree(&node, &bytes::Bytes::new()).unwrap();
     let expected = Tree::new(
         TreeBlob::try_from(bytes::Bytes::from_iter([2, 1, 2])).unwrap(),
-        vec![reference_1, reference_2],
+        TreeChildren::try_from(vec![reference_1, reference_2]).unwrap(),
     );
     assert_eq!(expected, tree);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Node API renamed from "size" to "count" and related aggregation/verification updated.

* **New Features / API**
  * Added TreeChildren and DeepTreeChildren wrappers and TREE_MAX_CHILDREN; constructors now accept children wrappers.
  * Added TreeSerializationError to surface serialization failures.

* **API Changes**
  * Some functions now return Option or Result to reflect child-limit or serialization errors.

* **Tests**
  * Tests and expected outputs updated to use children wrappers and the renamed node accessor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->