### PR TITLE
Prolly tree builds much larger chunks, respecting the max tree blob size

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -63,3 +63,10 @@ path = "fuzz_targets/prolly-tree-editable-node-remove.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "prolly-tree-size-tracker"
+path = "fuzz_targets/prolly-tree-size-tracker.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_functions/src/lib.rs
+++ b/fuzz/fuzz_functions/src/lib.rs
@@ -2,4 +2,5 @@ pub mod lambda_compiler_parse;
 pub mod lambda_compiler_tokenize;
 pub mod prolly_tree_editable_node_insert;
 pub mod prolly_tree_editable_node_remove;
+pub mod prolly_tree_size_tracker;
 pub mod sorted_tree_insert;

--- a/fuzz/fuzz_functions/src/prolly_tree_size_tracker.rs
+++ b/fuzz/fuzz_functions/src/prolly_tree_size_tracker.rs
@@ -1,0 +1,69 @@
+use arbitrary::{Arbitrary, Unstructured};
+use astraea::storage::LoadTree;
+use pretty_assertions::assert_eq;
+use sorted_tree::prolly_tree_editable_node::{EditableLeafNode, EditableLoadedNode, SizeTracker};
+use std::collections::BTreeMap;
+use tokio::sync::Mutex;
+
+#[derive(Arbitrary, Debug)]
+struct TestCase {
+    entries: BTreeMap<u32, i64>,
+}
+
+async fn run_test_case(test_case: &TestCase) -> bool {
+    let mut node = EditableLoadedNode::Leaf(
+        match EditableLeafNode::<u32, i64>::create(test_case.entries.clone()) {
+            Some(node) => node,
+            None => return false,
+        },
+    );
+    let storage = astraea::storage::InMemoryTreeStorage::new(Mutex::new(BTreeMap::new()));
+    let digest = node.save(&storage).await.unwrap();
+
+    let mut size_tracker = SizeTracker::new();
+    for (key, value) in test_case.entries.iter() {
+        size_tracker.add_entry(key, value);
+    }
+
+    let tree = storage.load_tree(&digest).await.unwrap();
+    let hashed_tree = tree.hash().unwrap();
+    assert_eq!(
+        hashed_tree.tree().blob().len() as usize,
+        size_tracker.size()
+    );
+    true
+}
+
+pub fn fuzz_function(data: &[u8]) -> bool {
+    let mut unstructured = Unstructured::new(data);
+    let test_case: TestCase = match unstructured.arbitrary() {
+        Ok(success) => success,
+        Err(_) => return false,
+    };
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(async { run_test_case(&test_case).await })
+}
+
+#[cfg(test)]
+#[test_log::test(tokio::test)]
+async fn test_empty() {
+    assert!(
+        !run_test_case(&TestCase {
+            entries: BTreeMap::new(),
+        })
+        .await
+    );
+}
+
+#[cfg(test)]
+#[test_log::test(tokio::test)]
+async fn test_one() {
+    assert!(
+        run_test_case(&TestCase {
+            entries: BTreeMap::from([(123, 456)]),
+        })
+        .await
+    );
+}

--- a/fuzz/fuzz_targets/prolly-tree-size-tracker.rs
+++ b/fuzz/fuzz_targets/prolly-tree-size-tracker.rs
@@ -1,0 +1,18 @@
+// libfuzzer doesn't support Windows. no_main causes a linker error on Windows.
+#![cfg_attr(target_os = "linux", no_main)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    panic!("Fuzzing is not supported on this platform.");
+}
+
+use fuzz_functions::prolly_tree_size_tracker;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| -> libfuzzer_sys::Corpus {
+    if prolly_tree_size_tracker::fuzz_function(data) {
+        libfuzzer_sys::Corpus::Keep
+    } else {
+        libfuzzer_sys::Corpus::Reject
+    }
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split logic now uses serialized byte-size metrics (including small/large thresholds) for more consistent chunking and memory behaviour.
  * Integrity checks updated to be size-aware.

* **New Features**
  * Added a public size-tracking utility to accumulate serialized entry sizes.
  * Public split-decision signature updated to accept chunk size in bytes.

* **Tests**
  * Updated unit expectations and added unit/fuzzing harnesses to validate size-tracking and serialization consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->