### PR TITLE
Save last modification time per directory entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "astraea",
  "async-stream",
  "bytes 1.11.0",
+ "chrono",
  "dav-server",
  "dogbox_tree",
  "dogbox_tree_editor",

--- a/dogbox/dogbox_dav_server/Cargo.toml
+++ b/dogbox/dogbox_dav_server/Cargo.toml
@@ -31,3 +31,4 @@ reqwest_dav = "0"
 test-log = {version = "0", features = ["trace", "log", "color"]}
 tempfile = "3"
 rand = { version = "0", features = [ "small_rng" ]}
+chrono = "0"

--- a/dogbox/dogbox_dav_server/src/file_system.rs
+++ b/dogbox/dogbox_dav_server/src/file_system.rs
@@ -1,7 +1,7 @@
 use async_stream::stream;
 use dav_server::fs::FsError;
 use dogbox_tree::serialization::DirectoryEntryKind;
-use dogbox_tree_editor::DirectoryEntryMetaData;
+use dogbox_tree::serialization::DirectoryEntryMetaData;
 use dogbox_tree_editor::NormalizedPath;
 use dogbox_tree_editor::OpenFile;
 use dogbox_tree_editor::OpenFileReadPermission;

--- a/dogbox/dogbox_tree_editor/src/lib_tests.rs
+++ b/dogbox/dogbox_tree_editor/src/lib_tests.rs
@@ -1,9 +1,9 @@
 use crate::{
     format_wall_clock, AccessOrderLowerIsMoreRecent, CacheDropStats, DigestStatus,
-    DirectoryEntryKind, DirectoryEntryMetaData, Error, FileCreationMode, LoadedBlock,
-    MutableDirectoryEntry, NamedEntry, NormalizedPath, OpenDirectory, OpenDirectoryStatus,
-    OpenFileContentBlock, OpenFileContentBuffer, OpenFileContentBufferLoaded, OpenFileStats,
-    OptimizedWriteBuffer, Prefetcher, StoreChanges, StreakDirection, TreeEditor, WallClock,
+    DirectoryEntryKind, Error, FileCreationMode, LoadedBlock, MutableDirectoryEntry, NamedEntry,
+    NormalizedPath, OpenDirectory, OpenDirectoryStatus, OpenFileContentBlock,
+    OpenFileContentBuffer, OpenFileContentBufferLoaded, OpenFileStats, OptimizedWriteBuffer,
+    Prefetcher, StoreChanges, StreakDirection, TreeEditor, WallClock,
 };
 use astraea::storage::{
     CollectGarbage, DelayedHashedTree, GarbageCollectionStats, InMemoryTreeStorage, LoadError,
@@ -15,7 +15,7 @@ use astraea::{
     tree::{BlobDigest, HashedTree, Tree, TreeBlob, TREE_BLOB_MAX_LENGTH},
 };
 use async_trait::async_trait;
-use dogbox_tree::serialization::FileName;
+use dogbox_tree::serialization::{DirectoryEntryMetaData, FileName};
 use futures::StreamExt;
 use lazy_static::lazy_static;
 use pretty_assertions::assert_eq;
@@ -355,6 +355,7 @@ async fn test_open_directory_nothing_happens() {
             1,
             0,
             OpenFileStats::new(0, 0, 0, 0, 0),
+            modified,
         ),
         status
     );
@@ -682,6 +683,7 @@ async fn test_read_file_after_garbage_collection() {
             1,
             0,
             OpenFileStats::new(0, 0, 0, 0, 0),
+            modified,
         ),
         &directory_status
     );

--- a/nonlocality_host/src/dav_server.rs
+++ b/nonlocality_host/src/dav_server.rs
@@ -11,10 +11,6 @@ pub async fn dav_server_main(
     info!("Serving DAV on http://{}", address);
     let clock = Arc::new(std::time::SystemTime::now);
     let modified_default = clock();
-    {
-        let time_string = chrono::DateTime::<chrono::Utc>::from(modified_default).to_rfc3339();
-        info!("Last modification time defaults to {}", &time_string);
-    }
     let (mut save_status_receiver, server, root_directory) = run_dav_server(
         listener,
         database_file_name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Metadata model updated so directory and file entries consistently carry and propagate modification timestamps.

* **Tests**
  * Test suite strengthened with deterministic clock utilities and ETAG-based verification for more reliable file/directory operation checks.

* **Chores**
  * Added a development dependency to support the enhanced testing setup.

* **Public API**
  * Public interfaces adjusted to surface modification timestamps for entries (impacting callers relying on entry metadata).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->