### PR TITLE
Import from Dropbox uses content hash for caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,6 +1084,7 @@ name = "dropbox_importer"
 version = "0.1.0"
 dependencies = [
  "astraea",
+ "async-stream",
  "async-trait",
  "bytes",
  "dogbox_tree",
@@ -1095,8 +1096,10 @@ dependencies = [
  "pretty_assertions",
  "relative-path",
  "sha2 0.11.0",
+ "sorted_tree",
  "test-case",
  "test-log",
+ "tokio",
  "tracing",
 ]
 
@@ -3964,6 +3967,7 @@ dependencies = [
  "dropbox_importer",
  "futures",
  "pretty_assertions",
+ "sorted_tree",
  "test-log",
  "tokio",
  "tracing",

--- a/dogbox/dropbox_importer/Cargo.toml
+++ b/dogbox/dropbox_importer/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 astraea = { path ="../../astraea" }
 dogbox_tree = { path ="../dogbox_tree" }
 dogbox_tree_editor = { path ="../dogbox_tree_editor" }
+sorted_tree = { path ="../../sorted_tree" }
 dropbox-sdk = {version = "0", features = ["async_routes", "default_async_client"]}
 tracing = "0"
 futures = "0"
@@ -17,6 +18,8 @@ relative-path = "2"
 async-trait = "0"
 sha2 = "0"
 hex = "0"
+async-stream = "0"
+tokio = {version = "1", features = ["sync"]}
 
 [dev-dependencies]
 test-case = "3"

--- a/dogbox/dropbox_importer/src/file_cache.rs
+++ b/dogbox/dropbox_importer/src/file_cache.rs
@@ -1,0 +1,224 @@
+use crate::Sha256Digest;
+use astraea::storage::{LoadTree, StoreTree, StrongReference, UpdateRoot};
+use async_trait::async_trait;
+use tracing::info;
+
+#[async_trait]
+pub trait FileCache: Send + Sync {
+    async fn require<'t>(
+        &'t self,
+        dropbox_content_hash: &Sha256Digest,
+        download_file: Box<
+            dyn FnOnce() -> std::pin::Pin<
+                    Box<
+                        dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
+                            + Send
+                            + 't,
+                    >,
+                > + Send
+                + 't,
+        >,
+    ) -> std::io::Result<(StrongReference, u64)>;
+}
+
+pub type Sha256CacheKey = [u8; 32];
+
+#[derive(Debug, Clone)]
+pub struct PersistableFileCacheEntry {
+    content_reference: StrongReference,
+    content_size: u64,
+}
+
+impl sorted_tree::sorted_tree::NodeValue for PersistableFileCacheEntry {
+    type Content = u64;
+
+    fn has_child(_content: &Self::Content) -> bool {
+        true
+    }
+
+    fn from_content(content: Self::Content, child: &Option<StrongReference>) -> Self {
+        Self {
+            content_reference: child.clone().unwrap(),
+            content_size: content,
+        }
+    }
+
+    fn to_content(&self) -> Self::Content {
+        self.content_size
+    }
+
+    fn get_reference(&self) -> Option<StrongReference> {
+        Some(self.content_reference.clone())
+    }
+}
+
+pub struct PersistableFileCache<'a> {
+    entries: tokio::sync::Mutex<
+        sorted_tree::prolly_tree_editable_node::EditableNode<
+            Sha256CacheKey,
+            PersistableFileCacheEntry,
+        >,
+    >,
+    load_tree: &'a (dyn LoadTree + Send + Sync),
+}
+
+impl<'a> PersistableFileCache<'a> {
+    pub fn new(
+        entries: sorted_tree::prolly_tree_editable_node::EditableNode<
+            Sha256CacheKey,
+            PersistableFileCacheEntry,
+        >,
+        load_tree: &'a (dyn LoadTree + Send + Sync),
+    ) -> Self {
+        Self {
+            entries: tokio::sync::Mutex::new(entries),
+            load_tree,
+        }
+    }
+
+    pub async fn number_of_entries(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        self.entries.lock().await.count(self.load_tree).await
+    }
+
+    pub async fn load(
+        reference: &StrongReference,
+        load_tree: &'a (dyn LoadTree + Send + Sync),
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let entries = sorted_tree::prolly_tree_editable_node::EditableNode::load(
+            reference.digest(),
+            load_tree,
+        )
+        .await?;
+        Ok(Self {
+            entries: tokio::sync::Mutex::new(entries),
+            load_tree,
+        })
+    }
+
+    pub async fn save(
+        &self,
+        store_tree: &(dyn StoreTree + Send + Sync),
+    ) -> Result<StrongReference, Box<dyn std::error::Error>> {
+        self.entries.lock().await.save(store_tree).await
+    }
+}
+
+#[async_trait]
+impl FileCache for PersistableFileCache<'_> {
+    async fn require<'t>(
+        &'t self,
+        dropbox_content_hash: &Sha256Digest,
+        download_file: Box<
+            dyn FnOnce() -> std::pin::Pin<
+                    Box<
+                        dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
+                            + Send
+                            + 't,
+                    >,
+                > + Send
+                + 't,
+        >,
+    ) -> std::io::Result<(StrongReference, u64)> {
+        let cache_key: [u8; 32] = *dropbox_content_hash
+            .as_array::<32>()
+            .expect("Sha256Digest should always be 32 bytes");
+        // TODO: don't hold the lock during the download
+        let mut entries_locked = self.entries.lock().await;
+        let maybe_found = entries_locked
+            .find(&cache_key, self.load_tree)
+            .await
+            .map_err(|e| {
+                std::io::Error::other(format!("Failed to find key in download cache: {e}"))
+            })?;
+        match maybe_found {
+            Some(entry) => {
+                info!("Cache hit for content hash {}", hex::encode(cache_key));
+                Ok((entry.content_reference, entry.content_size))
+            }
+            None => {
+                info!("Cache miss for content hash {}", hex::encode(cache_key));
+                let (content_reference, content_size) = download_file().await?;
+                let new_entry = PersistableFileCacheEntry {
+                    content_reference: content_reference.clone(),
+                    content_size,
+                };
+                entries_locked
+                    .insert(cache_key, new_entry, self.load_tree)
+                    .await
+                    .map_err(|e| {
+                        std::io::Error::other(format!(
+                            "Failed to insert key into download cache: {e}"
+                        ))
+                    })?;
+                Ok((content_reference, content_size))
+            }
+        }
+    }
+}
+
+pub struct PersistentFileCache<'a> {
+    original_cache: PersistableFileCache<'a>,
+    store_tree: &'a (dyn StoreTree + Send + Sync),
+    update_root: &'a (dyn UpdateRoot + Send + Sync),
+    root_name: String,
+}
+
+impl<'a> PersistentFileCache<'a> {
+    pub fn new(
+        original_cache: PersistableFileCache<'a>,
+        store_tree: &'a (dyn StoreTree + Send + Sync),
+        update_root: &'a (dyn UpdateRoot + Send + Sync),
+        root_name: String,
+    ) -> Self {
+        Self {
+            original_cache,
+            store_tree,
+            update_root,
+            root_name,
+        }
+    }
+
+    pub async fn number_of_entries(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        self.original_cache.number_of_entries().await
+    }
+}
+
+#[async_trait]
+impl FileCache for PersistentFileCache<'_> {
+    async fn require<'t>(
+        &'t self,
+        dropbox_content_hash: &Sha256Digest,
+        download_file: Box<
+            dyn FnOnce() -> std::pin::Pin<
+                    Box<
+                        dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
+                            + Send
+                            + 't,
+                    >,
+                > + Send
+                + 't,
+        >,
+    ) -> std::io::Result<(StrongReference, u64)> {
+        let success = self
+            .original_cache
+            .require(dropbox_content_hash, download_file)
+            .await?;
+        // TODO: only save and update root if the cache was modified (i.e. if it was a cache miss)
+        let saved = self
+            .original_cache
+            .save(self.store_tree)
+            .await
+            .map_err(|e| {
+                std::io::Error::other(format!("Failed to save file cache after download: {e}"))
+            })?;
+        self.update_root
+            .update_root(&self.root_name, &saved)
+            .await
+            .map_err(|e| {
+                std::io::Error::other(format!(
+                    "Failed to update root after saving file cache: {e}"
+                ))
+            })?;
+        Ok(success)
+    }
+}

--- a/dogbox/dropbox_importer/src/file_cache_tests.rs
+++ b/dogbox/dropbox_importer/src/file_cache_tests.rs
@@ -1,0 +1,298 @@
+use crate::file_cache::{FileCache, PersistableFileCache, PersistentFileCache};
+use astraea::{
+    in_memory_storage::InMemoryTreeStorage,
+    storage::{StoreError, StoreTree, StrongReference, UpdateRoot},
+    tree::{BlobDigest, HashedTree, Tree, TreeBlob, TreeChildren},
+};
+use async_trait::async_trait;
+use bytes::Bytes;
+use pretty_assertions::assert_eq;
+use std::{pin::Pin, sync::Arc};
+
+#[test_log::test(tokio::test)]
+async fn test_require_miss_and_hit() {
+    let storage = InMemoryTreeStorage::empty();
+    let cache = PersistableFileCache::new(
+        sorted_tree::prolly_tree_editable_node::EditableNode::new(),
+        &storage,
+    );
+    let reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::try_from(Bytes::new()).unwrap(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let length = 0u64;
+    let dropbox_content_hash = [0u8; 32].into();
+    let download_file_counter = Arc::new(tokio::sync::Mutex::new(0));
+    let make_download_file = || {
+        let reference = reference.clone();
+        let download_file_counter = download_file_counter.clone();
+        Box::new(move || {
+            Box::pin(async move {
+                let mut counter = download_file_counter.lock().await;
+                *counter += 1;
+                Ok((reference, length))
+            }) as Pin<Box<dyn std::future::Future<Output = Result<(_, u64), _>> + Send>>
+        })
+    };
+    assert_eq!(0, cache.number_of_entries().await.unwrap());
+    assert_eq!(0, *download_file_counter.lock().await);
+    // cache miss
+    {
+        let (result_reference, result_length) = cache
+            .require(&dropbox_content_hash, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, cache.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+    }
+    // cache hit
+    {
+        let (result_reference, result_length) = cache
+            .require(&dropbox_content_hash, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, cache.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_download_error() {
+    let storage = InMemoryTreeStorage::empty();
+    let cache = PersistableFileCache::new(
+        sorted_tree::prolly_tree_editable_node::EditableNode::new(),
+        &storage,
+    );
+    let dropbox_content_hash = [0u8; 32].into();
+    let download_file_counter = Arc::new(tokio::sync::Mutex::new(0));
+    let make_download_file = || {
+        let download_file_counter = download_file_counter.clone();
+        Box::new(move || {
+            Box::pin(async move {
+                let mut counter = download_file_counter.lock().await;
+                *counter += 1;
+                Err(std::io::Error::other("simulated download error"))
+            }) as Pin<Box<dyn std::future::Future<Output = Result<(_, u64), _>> + Send>>
+        })
+    };
+    assert_eq!(0, cache.number_of_entries().await.unwrap());
+    assert_eq!(0, *download_file_counter.lock().await);
+    // download will fail
+    let error = cache
+        .require(&dropbox_content_hash, make_download_file())
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::Other);
+    assert_eq!(error.to_string(), "simulated download error");
+    assert_eq!(0, cache.number_of_entries().await.unwrap());
+    assert_eq!(1, *download_file_counter.lock().await);
+}
+
+#[test_log::test(tokio::test)]
+async fn test_save_and_load_empty() {
+    let storage = InMemoryTreeStorage::empty();
+    let original_cache = PersistableFileCache::new(
+        sorted_tree::prolly_tree_editable_node::EditableNode::new(),
+        &storage,
+    );
+    let cache_saved_reference = original_cache.save(&storage).await.unwrap();
+    assert_eq!(
+        cache_saved_reference.digest(),
+        &BlobDigest::parse_hex_string(concat!(
+            "ddc92a915fca9a8ce7eebd29f715e8c6c7d58989090f98ae6d6073bbb04d7a27",
+            "01a541d1d64871c4d8773bee38cec8cb3981e60d2c4916a1603d85a073de45c2"
+        ))
+        .unwrap()
+    );
+    let cache_loaded = PersistableFileCache::load(&cache_saved_reference, &storage)
+        .await
+        .unwrap();
+    assert_eq!(0, cache_loaded.number_of_entries().await.unwrap());
+}
+
+#[test_log::test(tokio::test)]
+async fn test_save_and_load_non_empty() {
+    let storage = InMemoryTreeStorage::empty();
+    let original_cache = PersistableFileCache::new(
+        sorted_tree::prolly_tree_editable_node::EditableNode::new(),
+        &storage,
+    );
+    let reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::try_from(Bytes::new()).unwrap(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let length = 0u64;
+    let dropbox_content_hash = [0u8; 32].into();
+    let download_file_counter = Arc::new(tokio::sync::Mutex::new(0));
+    let make_download_file = || {
+        let reference = reference.clone();
+        let download_file_counter = download_file_counter.clone();
+        Box::new(move || {
+            Box::pin(async move {
+                let mut counter = download_file_counter.lock().await;
+                *counter += 1;
+                Ok((reference, length))
+            }) as Pin<Box<dyn std::future::Future<Output = Result<(_, u64), _>> + Send>>
+        })
+    };
+    assert_eq!(0, original_cache.number_of_entries().await.unwrap());
+    assert_eq!(0, *download_file_counter.lock().await);
+    // add a cache entry
+    {
+        let (result_reference, result_length) = original_cache
+            .require(&dropbox_content_hash, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, original_cache.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+    }
+    let cache_saved_reference = original_cache.save(&storage).await.unwrap();
+    assert_eq!(
+        cache_saved_reference.digest(),
+        &BlobDigest::parse_hex_string(concat!(
+            "c60dd06756407b0172e88764989064e8d33c82b806857e4583f04d4a476a7db0",
+            "451386f53a924b79ee787d66b079c381257fbdb60b138a2a00dfda70943e054a"
+        ))
+        .unwrap()
+    );
+    let cache_loaded = PersistableFileCache::load(&cache_saved_reference, &storage)
+        .await
+        .unwrap();
+    assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
+    // the entry should still exist
+    {
+        let (result_reference, result_length) = cache_loaded
+            .require(&dropbox_content_hash, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+    }
+}
+
+struct PersistentSaveAndLoadNonEmptyUpdateRoot {
+    current_value: tokio::sync::Mutex<Option<StrongReference>>,
+}
+
+impl PersistentSaveAndLoadNonEmptyUpdateRoot {
+    pub fn new() -> Self {
+        Self {
+            current_value: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    pub async fn current_value(&self) -> Option<StrongReference> {
+        self.current_value.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl UpdateRoot for PersistentSaveAndLoadNonEmptyUpdateRoot {
+    async fn update_root(
+        &self,
+        name: &str,
+        target: &StrongReference,
+    ) -> std::result::Result<(), StoreError> {
+        assert_eq!(name, "test_root");
+        let mut current_value = self.current_value.lock().await;
+        *current_value = Some(target.clone());
+        Ok(())
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_persistent_save_and_load_non_empty() {
+    let storage = InMemoryTreeStorage::empty();
+    let update_root = PersistentSaveAndLoadNonEmptyUpdateRoot::new();
+    let original_cache = PersistentFileCache::new(
+        PersistableFileCache::new(
+            sorted_tree::prolly_tree_editable_node::EditableNode::new(),
+            &storage,
+        ),
+        &storage,
+        &update_root,
+        "test_root".to_string(),
+    );
+    let reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::try_from(Bytes::new()).unwrap(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let length = 0u64;
+    let dropbox_content_hash = [0u8; 32].into();
+    let download_file_counter = Arc::new(tokio::sync::Mutex::new(0));
+    let make_download_file = || {
+        let reference = reference.clone();
+        let download_file_counter = download_file_counter.clone();
+        Box::new(move || {
+            Box::pin(async move {
+                let mut counter = download_file_counter.lock().await;
+                *counter += 1;
+                Ok((reference, length))
+            }) as Pin<Box<dyn std::future::Future<Output = Result<(_, u64), _>> + Send>>
+        })
+    };
+    assert_eq!(0, original_cache.number_of_entries().await.unwrap());
+    assert_eq!(0, *download_file_counter.lock().await);
+    assert_eq!(None, update_root.current_value().await);
+    // add a cache entry
+    {
+        let (result_reference, result_length) = original_cache
+            .require(&dropbox_content_hash, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, original_cache.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+    }
+    let cache_saved_reference = update_root.current_value().await.unwrap();
+    assert_eq!(
+        cache_saved_reference.digest(),
+        &BlobDigest::parse_hex_string(concat!(
+            "c60dd06756407b0172e88764989064e8d33c82b806857e4583f04d4a476a7db0",
+            "451386f53a924b79ee787d66b079c381257fbdb60b138a2a00dfda70943e054a"
+        ))
+        .unwrap()
+    );
+    let cache_loaded = PersistentFileCache::new(
+        PersistableFileCache::load(&cache_saved_reference, &storage)
+            .await
+            .unwrap(),
+        &storage,
+        &update_root,
+        "test_root".to_string(),
+    );
+    assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
+    // the entry should still exist
+    {
+        let (result_reference, result_length) = cache_loaded
+            .require(&dropbox_content_hash, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+        assert_eq!(
+            update_root.current_value().await,
+            Some(cache_saved_reference)
+        );
+    }
+}

--- a/dogbox/dropbox_importer/src/lib.rs
+++ b/dogbox/dropbox_importer/src/lib.rs
@@ -1,8 +1,9 @@
-use crate::dropbox_content_hash::DropboxContentHasher;
+use crate::{dropbox_content_hash::DropboxContentHasher, file_cache::FileCache};
 use astraea::{
     storage::{LoadStoreTree, StrongReference},
     tree::TREE_BLOB_MAX_LENGTH,
 };
+use async_stream::stream;
 use async_trait::async_trait;
 use bytes::Bytes;
 use dogbox_tree::serialization::{FileName, FileNameError};
@@ -11,10 +12,10 @@ use dogbox_tree_editor::{
     TreeEditor, WallClock, DEFAULT_WRITE_BUFFER_IN_BLOCKS,
 };
 use dropbox_sdk::{async_routes::files, default_async_client::UserAuthDefaultClient};
-use futures::io::AsyncReadExt;
+use futures::{io::AsyncReadExt, StreamExt};
 use relative_path::RelativePath;
 use sha2::Sha256;
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, pin::Pin, sync::Arc};
 use tracing::{error, info, warn};
 
 #[cfg(test)]
@@ -24,6 +25,11 @@ mod dropbox_content_hash;
 
 #[cfg(test)]
 mod dropbox_content_hash_tests;
+
+pub mod file_cache;
+
+#[cfg(test)]
+mod file_cache_tests;
 
 pub type Sha256Digest = sha2::digest::Output<Sha256>;
 
@@ -37,26 +43,47 @@ pub fn parse_sha256_hex(content_hash_string: &str) -> Option<Sha256Digest> {
     }
 }
 
-// TODO: an implementation with caching using dropbox_content_hash as the cache key
+pub struct DropboxFileMetaData {
+    content_hash: Option<String>,
+    rev: String,
+}
+
+pub enum DropboxFolderEntryKind {
+    File { metadata: DropboxFileMetaData },
+    Folder,
+}
+
+pub struct DropboxFolderEntry {
+    pub name: String,
+    pub kind: DropboxFolderEntryKind,
+}
+
 #[async_trait]
-pub trait DownloadDropboxFile {
-    async fn download_dropbox_file(
+pub trait DropboxApi {
+    async fn download_file(
         &self,
-        dropbox_client: &UserAuthDefaultClient,
         dropbox_file_path: &str,
         dropbox_file_rev: &files::Rev,
         dropbox_content_hash: &Sha256Digest,
         storage: Arc<dyn LoadStoreTree + Send + Sync>,
     ) -> std::io::Result<(StrongReference, u64)>;
+
+    async fn list_folder(
+        &self,
+        dropbox_folder_path: &str,
+    ) -> std::io::Result<
+        Pin<Box<dyn futures::Stream<Item = std::io::Result<DropboxFolderEntry>> + Send>>,
+    >;
 }
 
-pub struct NonCachingDropboxFileDownloader;
+pub struct RealDropboxApi {
+    pub dropbox_client: Arc<UserAuthDefaultClient>,
+}
 
 #[async_trait]
-impl DownloadDropboxFile for NonCachingDropboxFileDownloader {
-    async fn download_dropbox_file(
+impl DropboxApi for RealDropboxApi {
+    async fn download_file(
         &self,
-        dropbox_client: &UserAuthDefaultClient,
         dropbox_file_path: &str,
         dropbox_file_rev: &files::Rev,
         dropbox_content_hash: &Sha256Digest,
@@ -67,15 +94,16 @@ impl DownloadDropboxFile for NonCachingDropboxFileDownloader {
         info!("Starting download for {}", dropbox_file_path);
         let download_arg = files::DownloadArg::new(dropbox_file_path.to_string())
             .with_rev(dropbox_file_rev.clone());
-        let response = match files::download(dropbox_client, &download_arg, None, None).await {
-            Ok(res) => res,
-            Err(e) => {
-                return Err(std::io::Error::other(format!(
-                    "Failed to download file {}: {e}",
-                    dropbox_file_path
-                )));
-            }
-        };
+        let response =
+            match files::download(self.dropbox_client.as_ref(), &download_arg, None, None).await {
+                Ok(res) => res,
+                Err(e) => {
+                    return Err(std::io::Error::other(format!(
+                        "Failed to download file {}: {e}",
+                        dropbox_file_path
+                    )));
+                }
+            };
 
         let file_size = match response.content_length {
             Some(size) => size,
@@ -186,6 +214,78 @@ impl DownloadDropboxFile for NonCachingDropboxFileDownloader {
         assert!(digest_status.is_digest_up_to_date);
         Ok((reference, file_size))
     }
+
+    async fn list_folder(
+        &self,
+        dropbox_folder_path: &str,
+    ) -> std::io::Result<
+        Pin<Box<dyn futures::Stream<Item = std::io::Result<DropboxFolderEntry>> + Send>>,
+    > {
+        let dropbox_client = self.dropbox_client.clone();
+        let dropbox_folder_path = dropbox_folder_path.to_string();
+        let mut list_folder_result = match files::list_folder(
+            dropbox_client.as_ref(),
+            &files::ListFolderArg::new(dropbox_folder_path.clone()).with_recursive(false),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                return Err(std::io::Error::other(format!(
+                    "Failed to list_folder {}: {e}",
+                    dropbox_folder_path
+                )));
+            }
+        };
+        Ok(Box::pin(stream! {
+            let mut cursor = list_folder_result.cursor;
+            loop {
+                info!("Directory entries: {}", list_folder_result.entries.len());
+                for entry in list_folder_result.entries {
+                    match entry {
+                        files::Metadata::Folder(entry) => {
+                            info!("Folder entry: {}", entry.name);
+                            yield Ok(DropboxFolderEntry { name: entry.name, kind: DropboxFolderEntryKind::Folder });
+                        }
+                        files::Metadata::File(entry) => {
+                            info!("File entry: {}", entry.name);
+                            yield Ok(DropboxFolderEntry { name: entry.name, kind: DropboxFolderEntryKind::File {
+                                metadata: DropboxFileMetaData {
+                                content_hash: entry.content_hash,
+                                rev: entry.rev,
+                            }}});
+                        }
+                        files::Metadata::Deleted(entry) => {
+                            info!("Ignoring deleted entry: {:?}", entry);
+                        }
+                    }
+                }
+                if !list_folder_result.has_more {
+                    break;
+                }
+                list_folder_result = match files::list_folder_continue(
+                    dropbox_client.as_ref(),
+                    &files::ListFolderContinueArg::new(cursor.clone()),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(e) => {
+                        error!("Error from list_folder_continue: {e}");
+                        yield Err(std::io::Error::other(format!(
+                            "Failed to list_folder_continue {}: {e}",
+                            dropbox_folder_path
+                        )));
+                        break;
+                    }
+                };
+                if cursor != list_folder_result.cursor {
+                    warn!("Dropbox list_folder_continue cursor changed. Normally it doesn't change.");
+                }
+                cursor = list_folder_result.cursor;
+            }
+        }))
+    }
 }
 
 enum ImportFileOutcome {
@@ -206,21 +306,22 @@ pub fn join_dropbox_path(parent: &str, child: &str) -> String {
 }
 
 async fn import_file(
-    dropbox_client: &UserAuthDefaultClient,
     from_directory: &str,
-    metadata: &files::FileMetadata,
+    file_name_raw: &str,
+    metadata: &DropboxFileMetaData,
     into_directory: &Arc<OpenDirectory>,
     storage: Arc<dyn LoadStoreTree + Send + Sync>,
-    download: &dyn DownloadDropboxFile,
+    dropbox_api: &(dyn DropboxApi + Send + Sync),
+    download_cache: &dyn FileCache,
 ) -> std::io::Result<ImportFileOutcome> {
-    let file_name = match FileName::try_from(metadata.name.clone()) {
+    let file_name = match FileName::try_from(file_name_raw) {
         Ok(success) => success,
         Err(e) => {
-            info!("Unsupported file name {}: {e}", metadata.name);
+            info!("Unsupported file name {}: {e}", file_name_raw);
             return Ok(ImportFileOutcome::UnsupportedFileName(e));
         }
     };
-    let dropbox_file_path = join_dropbox_path(from_directory, &metadata.name);
+    let dropbox_file_path = join_dropbox_path(from_directory, file_name_raw);
     let content_hash: Sha256Digest = match &metadata.content_hash {
         Some(content_hash_string) => match parse_sha256_hex(content_hash_string) {
             Some(hash) => hash,
@@ -239,18 +340,28 @@ async fn import_file(
             return Ok(ImportFileOutcome::MissingContentHash);
         }
     };
-    let (content_reference, content_size) = download
-        .download_dropbox_file(
-            dropbox_client,
-            &dropbox_file_path,
-            &metadata.rev,
-            &content_hash,
-            storage.clone(),
-        )
+    let (content_reference, content_size) = download_cache
+        .require(&content_hash, {
+            let dropbox_file_path = dropbox_file_path.clone();
+            let dropbox_file_rev = metadata.rev.clone();
+            let storage = storage.clone();
+            Box::new(move || {
+                Box::pin(async move {
+                    dropbox_api
+                        .download_file(
+                            &dropbox_file_path,
+                            &dropbox_file_rev,
+                            &content_hash,
+                            storage,
+                        )
+                        .await
+                })
+            })
+        })
         .await
         .map_err(|e| {
-            error!("Error downloading {}: {e}", metadata.name);
-            std::io::Error::other(format!("Failed to download {}: {e}", metadata.name))
+            error!("Error downloading {}: {e}", dropbox_file_path);
+            std::io::Error::other(format!("Failed to download {}: {e}", dropbox_file_path))
         })?;
     let open_file = into_directory
         .clone()
@@ -260,12 +371,12 @@ async fn import_file(
         )
         .await
         .map_err(|e| {
-            error!("Error opening file {}: {e}", metadata.name);
-            std::io::Error::other(format!("Failed to open file {}: {e}", metadata.name))
+            error!("Error opening file {}: {e}", file_name);
+            std::io::Error::other(format!("Failed to open file {}: {e}", file_name))
         })?;
     open_file.request_save().await.map_err(|e| {
-        error!("Error saving file {}: {e}", metadata.name);
-        std::io::Error::other(format!("Failed to save file {}: {e}", metadata.name))
+        error!("Error saving file {}: {e}", file_name);
+        std::io::Error::other(format!("Failed to save file {}: {e}", file_name))
     })?;
     Ok(ImportFileOutcome::Success)
 }
@@ -276,43 +387,42 @@ enum ImportFolderOutcome {
 }
 
 struct DropboxImporter<'t> {
-    dropbox_client: &'t UserAuthDefaultClient,
     storage: Arc<dyn LoadStoreTree + Send + Sync>,
     empty_directory_reference: &'t StrongReference,
-    download: &'t dyn DownloadDropboxFile,
+    dropbox_api: &'t (dyn DropboxApi + Send + Sync),
+    download_cache: &'t dyn FileCache,
 }
 
 impl<'t> DropboxImporter<'t> {
     async fn import_folder(
         &self,
         from_directory: &str,
-        metadata: &files::FolderMetadata,
+        folder_name_raw: &str,
         into_directory: &Arc<OpenDirectory>,
     ) -> std::io::Result<ImportFolderOutcome> {
-        let folder_name = match FileName::try_from(metadata.name.clone()) {
+        let folder_name = match FileName::try_from(folder_name_raw) {
             Ok(success) => success,
             Err(e) => {
-                info!("Unsupported folder name {}: {e}", metadata.name);
+                info!("Unsupported folder name {}: {e}", folder_name_raw);
                 return Ok(ImportFolderOutcome::UnsupportedFileName(e));
             }
         };
-        let relative_path =
-            match NormalizedPath::try_from(RelativePath::new(metadata.name.as_str())) {
-                Ok(success) => success,
-                Err(e) => {
-                    info!("Unsupported folder name {}: {e}", metadata.name);
-                    return Ok(ImportFolderOutcome::UnsupportedFileName(e));
-                }
-            };
+        let relative_path = match NormalizedPath::try_from(RelativePath::new(folder_name_raw)) {
+            Ok(success) => success,
+            Err(e) => {
+                info!("Unsupported folder name {}: {e}", folder_name_raw);
+                return Ok(ImportFolderOutcome::UnsupportedFileName(e));
+            }
+        };
         into_directory
             .clone()
             .create_subdirectory(folder_name, self.empty_directory_reference)
             .await
             .map_err(|e| {
-                error!("Error creating subdirectory {}: {e}", metadata.name);
+                error!("Error creating subdirectory {}: {e}", folder_name_raw);
                 std::io::Error::other(format!(
                     "Failed to create subdirectory {}: {e}",
-                    metadata.name
+                    folder_name_raw
                 ))
             })?;
         let open_subdirectory = into_directory
@@ -320,14 +430,14 @@ impl<'t> DropboxImporter<'t> {
             .open_directory(relative_path)
             .await
             .map_err(|e| {
-                error!("Error opening subdirectory {}: {e}", metadata.name);
+                error!("Error opening subdirectory {}: {e}", folder_name_raw);
                 std::io::Error::other(format!(
                     "Failed to open subdirectory {}: {e}",
-                    metadata.name
+                    folder_name_raw
                 ))
             })?;
         Box::pin(self.import_directory_impl(
-            &join_dropbox_path(from_directory, &metadata.name),
+            &join_dropbox_path(from_directory, folder_name_raw),
             &open_subdirectory,
         ))
         .await?;
@@ -340,116 +450,76 @@ impl<'t> DropboxImporter<'t> {
         into_directory: &Arc<OpenDirectory>,
     ) -> std::io::Result<()> {
         info!("Listing Dropbox directory {}", from_directory);
-        let mut list_folder_result = match files::list_folder(
-            self.dropbox_client,
-            &files::ListFolderArg::new(from_directory.to_string()).with_recursive(false),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                return Err(std::io::Error::other(format!(
-                    "Failed to list_folder {}: {e}",
-                    from_directory
-                )));
-            }
-        };
-        let mut cursor = list_folder_result.cursor;
-        loop {
-            info!("Directory entries: {}", list_folder_result.entries.len());
-            for entry in list_folder_result.entries {
-                match entry {
-                    files::Metadata::Folder(entry) => {
-                        info!("Folder entry: {}", entry.name);
-                        match self
-                            .import_folder(from_directory, &entry, into_directory)
-                            .await?
-                        {
-                            ImportFolderOutcome::Success => {
-                                info!("Successfully imported folder {}", entry.name);
-                            }
-                            ImportFolderOutcome::UnsupportedFileName(e) => {
-                                // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                                warn!(
-                                    "Skipping folder {} due to unsupported folder name: {e}",
-                                    entry.name
-                                );
-                            }
-                        }
-                    }
-                    files::Metadata::File(entry) => {
-                        info!("File entry: {}", entry.name);
-                        match import_file(
-                            self.dropbox_client,
-                            from_directory,
-                            &entry,
-                            into_directory,
-                            self.storage.clone(),
-                            self.download,
-                        )
+        let mut folder_entries = self.dropbox_api.list_folder(from_directory).await?;
+        while let Some(entry_result) = folder_entries.next().await {
+            let entry = entry_result?;
+            match entry.kind {
+                DropboxFolderEntryKind::Folder => {
+                    info!("Folder entry: {}", entry.name);
+                    match self
+                        .import_folder(from_directory, &entry.name, into_directory)
                         .await?
-                        {
-                            ImportFileOutcome::Success => {
-                                info!("Successfully imported file {}", entry.name);
-                            }
-                            ImportFileOutcome::UnsupportedFileName(e) => {
-                                // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                                warn!(
-                                    "Skipping file {} due to unsupported file name: {e}",
-                                    entry.name
-                                );
-                            }
-                            ImportFileOutcome::MissingContentHash => {
-                                // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                                warn!("Skipping file {} due to missing content hash", entry.name);
-                            }
-                            ImportFileOutcome::InvalidContentHash(content_hash_string) => {
-                                // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                                warn!(
-                                    "Skipping file {} due to invalid content hash: {}",
-                                    entry.name, content_hash_string
-                                );
-                            }
+                    {
+                        ImportFolderOutcome::Success => {
+                            info!("Successfully imported folder {}", entry.name);
+                        }
+                        ImportFolderOutcome::UnsupportedFileName(e) => {
+                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                            warn!(
+                                "Skipping folder {} due to unsupported folder name: {e}",
+                                entry.name
+                            );
                         }
                     }
-                    files::Metadata::Deleted(entry) => {
-                        info!("Ignoring deleted entry: {:?}", entry);
+                }
+                DropboxFolderEntryKind::File { metadata } => {
+                    info!("File entry: {}", entry.name);
+                    match import_file(
+                        from_directory,
+                        &entry.name,
+                        &metadata,
+                        into_directory,
+                        self.storage.clone(),
+                        self.dropbox_api,
+                        self.download_cache,
+                    )
+                    .await?
+                    {
+                        ImportFileOutcome::Success => {
+                            info!("Successfully imported file {}", entry.name);
+                        }
+                        ImportFileOutcome::UnsupportedFileName(e) => {
+                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                            warn!(
+                                "Skipping file {} due to unsupported file name: {e}",
+                                entry.name
+                            );
+                        }
+                        ImportFileOutcome::MissingContentHash => {
+                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                            warn!("Skipping file {} due to missing content hash", entry.name);
+                        }
+                        ImportFileOutcome::InvalidContentHash(content_hash_string) => {
+                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                            warn!(
+                                "Skipping file {} due to invalid content hash: {}",
+                                entry.name, content_hash_string
+                            );
+                        }
                     }
                 }
             }
-            if !list_folder_result.has_more {
-                break;
-            }
-            list_folder_result = match files::list_folder_continue(
-                self.dropbox_client,
-                &files::ListFolderContinueArg::new(cursor.clone()),
-            )
-            .await
-            {
-                Ok(result) => result,
-                Err(e) => {
-                    error!("Error from list_folder_continue: {e}");
-                    return Err(std::io::Error::other(format!(
-                        "Failed to list_folder_continue {}: {e}",
-                        from_directory
-                    )));
-                }
-            };
-            if cursor != list_folder_result.cursor {
-                warn!("Dropbox list_folder_continue cursor changed. Normally it doesn't change.");
-            }
-            cursor = list_folder_result.cursor;
         }
         Ok(())
     }
 }
 
 pub async fn import_directory(
-    dropbox_client: &UserAuthDefaultClient,
     from_directory: &str,
     storage: Arc<dyn LoadStoreTree + Send + Sync>,
     clock: WallClock,
-    download: &dyn DownloadDropboxFile,
+    dropbox_api: &(dyn DropboxApi + Send + Sync),
+    download_cache: &dyn FileCache,
 ) -> std::io::Result<Arc<OpenDirectory>> {
     let open_directory = Arc::new(
         OpenDirectory::create_directory(
@@ -466,10 +536,10 @@ pub async fn import_directory(
     );
     let empty_directory_reference = open_directory.latest_reference();
     let importer = DropboxImporter {
-        dropbox_client,
         storage,
         empty_directory_reference: &empty_directory_reference,
-        download,
+        dropbox_api,
+        download_cache,
     };
     importer
         .import_directory_impl(from_directory, &open_directory)

--- a/system_tests/Cargo.toml
+++ b/system_tests/Cargo.toml
@@ -10,6 +10,7 @@ astraea = { path ="../astraea" }
 dogbox_tree = { path ="../dogbox/dogbox_tree" }
 dogbox_tree_editor = { path ="../dogbox/dogbox_tree_editor" }
 dropbox_importer = { path ="../dogbox/dropbox_importer" }
+sorted_tree = { path ="../sorted_tree" }
 tokio = {version = "1", features = ["rt-multi-thread", "macros", "time", "fs", "process", "io-util", "signal", "io-std"]}
 tracing-subscriber = "0"
 tracing = "0"

--- a/system_tests/src/dropbox_importer_tests.rs
+++ b/system_tests/src/dropbox_importer_tests.rs
@@ -5,7 +5,10 @@ use astraea::{
 use bytes::Bytes;
 use dogbox_tree::serialization::{DirectoryEntryKind, FileName};
 use dogbox_tree_editor::{FileCreationMode, OpenDirectory, OpenFile};
-use dropbox_importer::NonCachingDropboxFileDownloader;
+use dropbox_importer::{
+    file_cache::{PersistableFileCache, PersistableFileCacheEntry, Sha256CacheKey},
+    RealDropboxApi,
+};
 use dropbox_sdk::{default_async_client::UserAuthDefaultClient, oauth2::Authorization};
 use futures::StreamExt;
 use pretty_assertions::assert_eq;
@@ -144,6 +147,7 @@ async fn verify_import(
         Box<dyn std::future::Future<Output = std::io::Result<()>> + Send>,
     >,
     expected_digest: &BlobDigest,
+    expected_file_cache_entries: u64,
 ) {
     info!("\n==== verify_import: {} ====", test_case_name);
     clear_or_create_directory(dropbox_client, dropbox_test_directory)
@@ -154,13 +158,21 @@ async fn verify_import(
         .expect("Failed to set up Dropbox test directory");
     let storage = Arc::new(InMemoryTreeStorage::empty());
     let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
-    let dropbox_downloader = NonCachingDropboxFileDownloader {};
+    let dropbox_api = RealDropboxApi {
+        dropbox_client: dropbox_client.clone(),
+    };
+    // We do not reuse the cache across test runs because we want to test Dropbox API calls.
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256CacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let download_cache = PersistableFileCache::new(download_cache_tree, &*storage);
     let open_directory = dropbox_importer::import_directory(
-        dropbox_client,
         dropbox_test_directory,
-        storage,
+        storage.clone(),
         clock,
-        &dropbox_downloader,
+        &dropbox_api,
+        &download_cache,
     )
     .await
     .expect("Failed to import Dropbox directory");
@@ -173,6 +185,10 @@ async fn verify_import(
         .expect("Failed to verify imported directory");
     assert!(status.digest.is_digest_up_to_date);
     assert_eq!(expected_digest, status.digest.last_known_digest.digest());
+    assert_eq!(
+        download_cache.number_of_entries().await.unwrap(),
+        expected_file_cache_entries
+    );
 }
 
 async fn read_to_end(open_file: &OpenFile) -> std::io::Result<Bytes> {
@@ -256,6 +272,7 @@ async fn create_and_import_and_verify(
     dropbox_test_directory: &str,
     entries: BTreeMap<FileName, ExpectedDirectoryEntryKind>,
     expected_digest: &BlobDigest,
+    expected_file_cache_entries: u64,
 ) {
     verify_import(
         test_case_name,
@@ -278,6 +295,7 @@ async fn create_and_import_and_verify(
             })
         },
         expected_digest,
+        expected_file_cache_entries,
     )
     .await;
 }
@@ -335,6 +353,7 @@ async fn verify_illegal_character_handling(
             "5663706bc757215e339cc5ef49d7ac9231d367d1b8a8333778ae1bda765caf76"
         ))
         .unwrap(),
+        1,
     )
     .await;
 }
@@ -358,6 +377,7 @@ pub async fn test_dropbox_importer(
             "01a541d1d64871c4d8773bee38cec8cb3981e60d2c4916a1603d85a073de45c2"
         ))
         .unwrap(),
+        0,
     )
     .await;
 
@@ -374,6 +394,7 @@ pub async fn test_dropbox_importer(
             "7d8f8f87ed9cb78cdd2025f22b7c2262ef1b70ed69da7bcd032c91dc2831e9c8"
         ))
         .unwrap(),
+        0,
     )
     .await;
 
@@ -394,6 +415,7 @@ pub async fn test_dropbox_importer(
             "5cd78645b4d26a7420bbe8acaa8f7c1f5d3b2349b92f6e3ee0d159bc02f0decf"
         ))
         .unwrap(),
+        1,
     )
     .await;
 
@@ -413,11 +435,12 @@ pub async fn test_dropbox_importer(
             "b51476eb0db6551e0da6d23d0e6ce3603793b46958b902b42b417f26e6119019"
         ))
         .unwrap(),
+        1,
     )
     .await;
 
     create_and_import_and_verify(
-        "Directory with several files",
+        "Directory with several different files",
         &dropbox_client,
         dropbox_test_directory,
         BTreeMap::from_iter((1..=5).map(|i| {
@@ -431,6 +454,29 @@ pub async fn test_dropbox_importer(
             "7821a9c978070176428428c61da996ad5022ac82ad3f82c4a70d112f6d2f318c"
         ))
         .unwrap(),
+        5,
+    )
+    .await;
+
+    // test file download caching
+    create_and_import_and_verify(
+        "Directory with several equal files",
+        &dropbox_client,
+        dropbox_test_directory,
+        BTreeMap::from_iter((1..=3).map(|i| {
+            (
+                FileName::try_from(format!("{}.txt", i)).unwrap(),
+                ExpectedDirectoryEntryKind::File(Bytes::from(
+                    "This is the same content for all files",
+                )),
+            )
+        })),
+        &BlobDigest::parse_hex_string(concat!(
+            "c9c5fded1d6abccfa626ca711483e2fd6bb49fffab2a40d12ac2394f87d77820",
+            "5cd08bf9d2271af7eb7725d67bfb92e7eadb9237d2842b127146012651e9406b"
+        ))
+        .unwrap(),
+        1,
     )
     .await;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dropbox importer now uses a unified API for downloads and folder listings; public import entry accepts API and cache abstractions.

* **New Features**
  * Directory listings stream entries and ignore deleted items.
  * Added a persistent, content-addressed file-download cache with entry-count tracking and deduplication.

* **Tests**
  * Integration and unit tests updated to verify API/cache behaviour, including deduplicated identical-file scenarios and cache persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->