### PR TITLE
Handle deserialization errors in sorted_tree

### DIFF
--- a/sorted_tree/src/prolly_tree_editable_node.rs
+++ b/sorted_tree/src/prolly_tree_editable_node.rs
@@ -148,14 +148,14 @@ pub async fn load_node<
             tree.blob(),
             &children,
             tree.blob().as_slice().len() - sorted_tree_data.len(),
-        );
+        )?;
         Ok(EitherNodeType::Leaf(node))
     } else {
         let node = sorted_tree::node_from_tree::<Key, TreeReference>(
             tree.blob(),
             &children,
             tree.blob().as_slice().len() - sorted_tree_data.len(),
-        );
+        )?;
         Ok(EitherNodeType::Internal(node))
     }
 }

--- a/sorted_tree/src/sorted_tree.rs
+++ b/sorted_tree/src/sorted_tree.rs
@@ -131,6 +131,10 @@ pub struct SerializableNodeContent<Key: Serialize + Ord, Value: Serialize> {
 }
 
 impl<Key: Serialize + Ord, Value: Serialize> SerializableNodeContent<Key, Value> {
+    pub fn new(entries: Vec<(Key, Value)>) -> Self {
+        Self { entries }
+    }
+
     pub fn entries(&self) -> &Vec<(Key, Value)> {
         &self.entries
     }
@@ -177,64 +181,103 @@ pub async fn store_node<Key: Serialize + Ord, Value: NodeValue>(
         .await
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum NodeDeserializationError {
+    PostcardError(postcard::Error),
+    EntriesNotSorted,
+    TooManyChildren,
+    NotEnoughChildren,
+    DuplicateKeys,
+}
+
+impl std::fmt::Display for NodeDeserializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeDeserializationError::PostcardError(e) => write!(f, "postcard error: {}", e),
+            NodeDeserializationError::EntriesNotSorted => {
+                write!(f, "node entries are not sorted by key")
+            }
+            NodeDeserializationError::TooManyChildren => {
+                write!(
+                    f,
+                    "node has more children than expected based on its content"
+                )
+            }
+            NodeDeserializationError::NotEnoughChildren => {
+                write!(
+                    f,
+                    "node has fewer children than expected based on its content"
+                )
+            }
+            NodeDeserializationError::DuplicateKeys => {
+                write!(f, "node contains duplicate keys")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NodeDeserializationError {}
+
 pub fn node_from_tree<Key: Serialize + DeserializeOwned + Ord, Value: NodeValue>(
     tree_blob: &TreeBlob,
     children: &[StrongReference],
     metadata_to_skip: usize,
-) -> Node<Key, Value> {
+) -> Result<Node<Key, Value>, NodeDeserializationError> {
     let node = postcard::from_bytes::<SerializableNodeContent<Key, Value::Content>>(
         tree_blob.as_slice().split_at(metadata_to_skip).1,
     )
-    .expect("this should always work");
-    if !node.entries.is_sorted_by_key(|element| &element.0) {
-        todo!("loaded node is not sorted");
-    }
+    .map_err(NodeDeserializationError::PostcardError)?;
     let mut reference_iter = children.iter();
-    let result = Node {
-        entries: node
-            .entries
-            .into_iter()
-            .map(|(key, content)| {
-                if Value::has_child(&content) {
-                    let reference = match reference_iter.next() {
-                        Some(reference) => Some(reference.clone()),
-                        None => todo!("node claims to have a child, but no reference is available"),
-                    };
-                    (key, Value::from_content(content, &reference))
-                } else {
-                    (key, Value::from_content(content, &None))
+    let mut entries: Vec<(Key, Value)> = Vec::new();
+    for (key, content) in node.entries.into_iter() {
+        if let Some(last) = entries.last() {
+            match last.0.cmp(&key) {
+                std::cmp::Ordering::Less => {}
+                std::cmp::Ordering::Equal => return Err(NodeDeserializationError::DuplicateKeys),
+                std::cmp::Ordering::Greater => {
+                    return Err(NodeDeserializationError::EntriesNotSorted)
                 }
-            })
-            .collect(),
-    };
-    if reference_iter.next().is_some() {
-        todo!("more references available than expected")
+            }
+        }
+        if Value::has_child(&content) {
+            let reference = match reference_iter.next() {
+                Some(reference) => Some(reference.clone()),
+                None => return Err(NodeDeserializationError::NotEnoughChildren),
+            };
+            entries.push((key, Value::from_content(content, &reference)));
+        } else {
+            entries.push((key, Value::from_content(content, &None)));
+        }
     }
-    result
+    if reference_iter.next().is_some() {
+        return Err(NodeDeserializationError::TooManyChildren);
+    }
+    Ok(Node { entries })
 }
 
 pub async fn load_node<Key: Serialize + DeserializeOwned + Ord, Value: NodeValue>(
     load_tree: &(dyn LoadTree + Send + Sync),
     root: &BlobDigest,
-) -> Result<Node<Key, Value>, LoadError> {
+) -> Result<Node<Key, Value>, Box<dyn std::error::Error>> {
     let delayed_hashed_tree = match load_tree.load_tree(root).await {
         Ok(tree) => tree,
-        Err(_) => todo!(),
+        Err(error) => return Err(error.into()),
     };
     let hashed_tree = match delayed_hashed_tree.hash() {
         Some(tree) => tree,
-        None => todo!(),
+        None => {
+            return Err(
+                LoadError::Inconsistency(*root, "tree hash does not match".to_string()).into(),
+            )
+        }
     };
     let children = load_children(load_tree, hashed_tree.hashed_tree().tree())
         .await?
         .into_iter()
         .map(|child| child.reference().clone())
         .collect::<Vec<_>>();
-    Ok(node_from_tree::<Key, Value>(
-        hashed_tree.hashed_tree().tree().blob(),
-        &children,
-        0,
-    ))
+    node_from_tree::<Key, Value>(hashed_tree.hashed_tree().tree().blob(), &children, 0)
+        .map_err(|e| e.into())
 }
 
 pub async fn new_tree<Key: Serialize + Ord, Value: NodeValue>(

--- a/sorted_tree/src/sorted_tree_tests.rs
+++ b/sorted_tree/src/sorted_tree_tests.rs
@@ -1,8 +1,11 @@
-use crate::sorted_tree::{find, insert, load_node, new_tree, node_to_tree, Node, TreeReference};
+use crate::sorted_tree::{
+    find, insert, load_node, new_tree, node_from_tree, node_to_tree, Node,
+    NodeDeserializationError, SerializableNodeContent, TreeReference,
+};
 use astraea::{
     in_memory_storage::InMemoryTreeStorage,
     storage::StoreTree,
-    tree::{HashedTree, Tree, TreeBlob, TreeChildren},
+    tree::{BlobDigest, HashedTree, Tree, TreeBlob, TreeChildren},
 };
 use pretty_assertions::{assert_eq, assert_ne};
 use rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng};
@@ -397,6 +400,160 @@ async fn node_to_tree_with_child_references() {
         TreeChildren::try_from(vec![reference_1, reference_2]).unwrap(),
     );
     assert_eq!(expected, tree);
+}
+
+#[test_log::test]
+fn test_node_from_tree_success_empty() {
+    let blob = postcard::to_stdvec(&SerializableNodeContent::<u64, String>::new(vec![])).unwrap();
+    let node = node_from_tree::<u64, String>(
+        &TreeBlob::try_from(bytes::Bytes::from(blob)).unwrap(),
+        &[],
+        0,
+    )
+    .unwrap();
+    assert_eq!(&Vec::<(u64, String)>::new(), node.entries());
+}
+
+#[test_log::test]
+fn test_node_from_tree_success_flat() {
+    let blob = postcard::to_stdvec(&SerializableNodeContent::new(vec![
+        (1u64, "A".to_string()),
+        (2u64, "B".to_string()),
+    ]))
+    .unwrap();
+    let node = node_from_tree::<u64, String>(
+        &TreeBlob::try_from(bytes::Bytes::from(blob)).unwrap(),
+        &[],
+        0,
+    )
+    .unwrap();
+    assert_eq!(
+        &vec![(1u64, "A".to_string()), (2u64, "B".to_string())],
+        node.entries()
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_node_from_tree_success_child() {
+    let storage = InMemoryTreeStorage::empty();
+    let reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::try_from(bytes::Bytes::from_static(b"\x00")).unwrap(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let blob =
+        postcard::to_stdvec(&SerializableNodeContent::new(vec![(1u64, ()), (2u64, ())])).unwrap();
+    let node = node_from_tree::<u64, TreeReference>(
+        &TreeBlob::try_from(bytes::Bytes::from(blob)).unwrap(),
+        &[reference.clone(), reference.clone()],
+        0,
+    )
+    .unwrap();
+    assert_eq!(
+        node.entries(),
+        &vec![
+            (1u64, TreeReference::new(reference.clone())),
+            (2u64, TreeReference::new(reference))
+        ]
+    );
+}
+
+#[test_log::test]
+fn test_node_from_tree_entries_not_sorted() {
+    let blob = postcard::to_stdvec(&SerializableNodeContent::new(vec![
+        (2u64, "B".to_string()),
+        (1u64, "A".to_string()),
+    ]))
+    .unwrap();
+    assert_eq!(
+        Err(NodeDeserializationError::EntriesNotSorted),
+        node_from_tree::<u64, String>(
+            &TreeBlob::try_from(bytes::Bytes::from(blob)).unwrap(),
+            &[],
+            0,
+        )
+    );
+}
+
+#[test_log::test]
+fn test_node_from_tree_entries_duplicate() {
+    let blob = postcard::to_stdvec(&SerializableNodeContent::new(vec![
+        (1u64, "A".to_string()),
+        (1u64, "B".to_string()),
+    ]))
+    .unwrap();
+    assert_eq!(
+        Err(NodeDeserializationError::DuplicateKeys),
+        node_from_tree::<u64, String>(
+            &TreeBlob::try_from(bytes::Bytes::from(blob)).unwrap(),
+            &[],
+            0,
+        )
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_node_from_tree_not_enough_children() {
+    let storage = InMemoryTreeStorage::empty();
+    let reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::try_from(bytes::Bytes::from_static(b"\x00")).unwrap(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let blob =
+        postcard::to_stdvec(&SerializableNodeContent::new(vec![(1u64, ()), (2u64, ())])).unwrap();
+    assert_eq!(
+        node_from_tree::<u64, TreeReference>(
+            &TreeBlob::try_from(bytes::Bytes::from(blob)).unwrap(),
+            // one child is missing here
+            &[reference],
+            0,
+        ),
+        Err(NodeDeserializationError::NotEnoughChildren)
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_node_from_tree_too_many_children() {
+    let storage = InMemoryTreeStorage::empty();
+    let reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::try_from(bytes::Bytes::from_static(b"\x00")).unwrap(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let blob =
+        postcard::to_stdvec(&SerializableNodeContent::new(vec![(1u64, ()), (2u64, ())])).unwrap();
+    assert_eq!(
+        node_from_tree::<u64, TreeReference>(
+            &TreeBlob::try_from(bytes::Bytes::from(blob)).unwrap(),
+            // one child is too much here
+            &[reference.clone(), reference.clone(), reference],
+            0,
+        ),
+        Err(NodeDeserializationError::TooManyChildren)
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_load_node_error() {
+    let storage = InMemoryTreeStorage::empty();
+    let digest = BlobDigest::parse_hex_string(concat!(
+        "f0140e314ee38d4472393680e7a72a81abb36b134b467d90ea943b7aa1ea03bf",
+        "2323bc1a2df91f7230a225952e162f6629cf435e53404e9cdd727a2d94e4f909"
+    ))
+    .unwrap();
+    let error = load_node::<u64, String>(&storage, &digest)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        "TreeNotFound(BlobDigest(\"f0140e314ee38d4472393680e7a72a81abb36b134b467d90ea943b7aa1ea03bf2323bc1a2df91f7230a225952e162f6629cf435e53404e9cdd727a2d94e4f909\"))".to_string(),
+        error.to_string());
 }
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node loading now propagates deserialisation errors and surface them instead of ignoring failures, reducing silent corruption.
  * Improved, structured error reporting for decode, ordering and child-reference inconsistencies to make failures easier to diagnose.

* **New Features**
  * Added clearer deserialization error type to provide more specific failure reasons.

* **Tests**
  * Added tests covering successful and failing node deserialisation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->