### PR TITLE
Refactor Dropbox importer

### DIFF
--- a/dogbox/dropbox_importer/src/dropbox_api.rs
+++ b/dogbox/dropbox_importer/src/dropbox_api.rs
@@ -286,6 +286,7 @@ impl DropboxApi for RealDropboxApi {
         dropbox_content_hash: &Sha256Digest,
         storage: Arc<dyn LoadStoreTree + Send + Sync>,
     ) -> std::io::Result<(StrongReference, u64)> {
+        // We call this function because code coverage doesn't work for async_traits.
         download_file_impl(
             &self.dropbox_client,
             dropbox_file_path,
@@ -302,6 +303,7 @@ impl DropboxApi for RealDropboxApi {
     ) -> std::io::Result<
         Pin<Box<dyn futures::Stream<Item = std::io::Result<DropboxFolderEntry>> + Send>>,
     > {
+        // We call this function because code coverage doesn't work for async_traits.
         list_folder_impl(&self.dropbox_client, dropbox_folder_path).await
     }
 }

--- a/dogbox/dropbox_importer/src/file_cache.rs
+++ b/dogbox/dropbox_importer/src/file_cache.rs
@@ -52,7 +52,7 @@ impl sorted_tree::sorted_tree::NodeValue for PersistableFileCacheEntry {
     }
 }
 
-pub struct PersistableFileCache<'a> {
+pub struct FileCacheMap<'a> {
     entries: tokio::sync::Mutex<
         sorted_tree::prolly_tree_editable_node::EditableNode<
             Sha256CacheKey,
@@ -62,7 +62,7 @@ pub struct PersistableFileCache<'a> {
     load_tree: &'a (dyn LoadTree + Send + Sync),
 }
 
-impl<'a> PersistableFileCache<'a> {
+impl<'a> FileCacheMap<'a> {
     pub fn new(
         entries: sorted_tree::prolly_tree_editable_node::EditableNode<
             Sha256CacheKey,
@@ -104,7 +104,7 @@ impl<'a> PersistableFileCache<'a> {
 }
 
 #[async_trait]
-impl FileCache for PersistableFileCache<'_> {
+impl FileCache for FileCacheMap<'_> {
     async fn require<'t>(
         &'t self,
         dropbox_content_hash: &Sha256Digest,
@@ -156,16 +156,16 @@ impl FileCache for PersistableFileCache<'_> {
     }
 }
 
-pub struct PersistentFileCache<'a> {
-    original_cache: PersistableFileCache<'a>,
+pub struct PersistentFileCacheMap<'a> {
+    original_cache: FileCacheMap<'a>,
     store_tree: &'a (dyn StoreTree + Send + Sync),
     update_root: &'a (dyn UpdateRoot + Send + Sync),
     root_name: String,
 }
 
-impl<'a> PersistentFileCache<'a> {
+impl<'a> PersistentFileCacheMap<'a> {
     pub fn new(
-        original_cache: PersistableFileCache<'a>,
+        original_cache: FileCacheMap<'a>,
         store_tree: &'a (dyn StoreTree + Send + Sync),
         update_root: &'a (dyn UpdateRoot + Send + Sync),
         root_name: String,
@@ -184,7 +184,7 @@ impl<'a> PersistentFileCache<'a> {
 }
 
 #[async_trait]
-impl FileCache for PersistentFileCache<'_> {
+impl FileCache for PersistentFileCacheMap<'_> {
     async fn require<'t>(
         &'t self,
         dropbox_content_hash: &Sha256Digest,

--- a/dogbox/dropbox_importer/src/file_cache.rs
+++ b/dogbox/dropbox_importer/src/file_cache.rs
@@ -101,22 +101,19 @@ impl<'a> FileCacheMap<'a> {
     ) -> Result<StrongReference, Box<dyn std::error::Error>> {
         self.entries.lock().await.save(store_tree).await
     }
-}
 
-#[async_trait]
-impl FileCache for FileCacheMap<'_> {
-    async fn require<'t>(
-        &'t self,
+    async fn require_impl(
+        &'a self,
         dropbox_content_hash: &Sha256Digest,
         download_file: Box<
             dyn FnOnce() -> std::pin::Pin<
                     Box<
                         dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
                             + Send
-                            + 't,
+                            + 'a,
                     >,
                 > + Send
-                + 't,
+                + 'a,
         >,
     ) -> std::io::Result<(StrongReference, u64)> {
         let cache_key: [u8; 32] = *dropbox_content_hash
@@ -156,6 +153,27 @@ impl FileCache for FileCacheMap<'_> {
     }
 }
 
+#[async_trait]
+impl FileCache for FileCacheMap<'_> {
+    async fn require<'t>(
+        &'t self,
+        dropbox_content_hash: &Sha256Digest,
+        download_file: Box<
+            dyn FnOnce() -> std::pin::Pin<
+                    Box<
+                        dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
+                            + Send
+                            + 't,
+                    >,
+                > + Send
+                + 't,
+        >,
+    ) -> std::io::Result<(StrongReference, u64)> {
+        // We call this function because code coverage doesn't work for async_traits.
+        self.require_impl(dropbox_content_hash, download_file).await
+    }
+}
+
 pub struct PersistentFileCacheMap<'a> {
     original_cache: FileCacheMap<'a>,
     store_tree: &'a (dyn StoreTree + Send + Sync),
@@ -181,22 +199,19 @@ impl<'a> PersistentFileCacheMap<'a> {
     pub async fn number_of_entries(&self) -> Result<u64, Box<dyn std::error::Error>> {
         self.original_cache.number_of_entries().await
     }
-}
 
-#[async_trait]
-impl FileCache for PersistentFileCacheMap<'_> {
-    async fn require<'t>(
-        &'t self,
+    async fn require_impl(
+        &'a self,
         dropbox_content_hash: &Sha256Digest,
         download_file: Box<
             dyn FnOnce() -> std::pin::Pin<
                     Box<
                         dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
                             + Send
-                            + 't,
+                            + 'a,
                     >,
                 > + Send
-                + 't,
+                + 'a,
         >,
     ) -> std::io::Result<(StrongReference, u64)> {
         let success = self
@@ -220,5 +235,26 @@ impl FileCache for PersistentFileCacheMap<'_> {
                 ))
             })?;
         Ok(success)
+    }
+}
+
+#[async_trait]
+impl FileCache for PersistentFileCacheMap<'_> {
+    async fn require<'t>(
+        &'t self,
+        dropbox_content_hash: &Sha256Digest,
+        download_file: Box<
+            dyn FnOnce() -> std::pin::Pin<
+                    Box<
+                        dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
+                            + Send
+                            + 't,
+                    >,
+                > + Send
+                + 't,
+        >,
+    ) -> std::io::Result<(StrongReference, u64)> {
+        // We call this function because code coverage doesn't work for async_traits.
+        self.require_impl(dropbox_content_hash, download_file).await
     }
 }

--- a/dogbox/dropbox_importer/src/file_cache.rs
+++ b/dogbox/dropbox_importer/src/file_cache.rs
@@ -23,6 +23,17 @@ pub trait FileCache: Send + Sync {
 
 pub type Sha256CacheKey = [u8; 32];
 
+pub type DownloadFileCallback<'a> = Box<
+    dyn FnOnce() -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
+                    + Send
+                    + 'a,
+            >,
+        > + Send
+        + 'a,
+>;
+
 #[derive(Debug, Clone)]
 pub struct PersistableFileCacheEntry {
     content_reference: StrongReference,
@@ -105,16 +116,7 @@ impl<'a> FileCacheMap<'a> {
     async fn require_impl(
         &'a self,
         dropbox_content_hash: &Sha256Digest,
-        download_file: Box<
-            dyn FnOnce() -> std::pin::Pin<
-                    Box<
-                        dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
-                            + Send
-                            + 'a,
-                    >,
-                > + Send
-                + 'a,
-        >,
+        download_file: DownloadFileCallback<'a>,
     ) -> std::io::Result<(StrongReference, u64)> {
         let cache_key: [u8; 32] = *dropbox_content_hash
             .as_array::<32>()
@@ -203,16 +205,7 @@ impl<'a> PersistentFileCacheMap<'a> {
     async fn require_impl(
         &'a self,
         dropbox_content_hash: &Sha256Digest,
-        download_file: Box<
-            dyn FnOnce() -> std::pin::Pin<
-                    Box<
-                        dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
-                            + Send
-                            + 'a,
-                    >,
-                > + Send
-                + 'a,
-        >,
+        download_file: DownloadFileCallback<'a>,
     ) -> std::io::Result<(StrongReference, u64)> {
         let success = self
             .original_cache

--- a/dogbox/dropbox_importer/src/file_cache_tests.rs
+++ b/dogbox/dropbox_importer/src/file_cache_tests.rs
@@ -1,4 +1,4 @@
-use crate::file_cache::{FileCache, PersistableFileCache, PersistentFileCache};
+use crate::file_cache::{FileCache, FileCacheMap, PersistentFileCacheMap};
 use astraea::{
     in_memory_storage::InMemoryTreeStorage,
     storage::{StoreError, StoreTree, StrongReference, UpdateRoot},
@@ -12,7 +12,7 @@ use std::{pin::Pin, sync::Arc};
 #[test_log::test(tokio::test)]
 async fn test_require_miss_and_hit() {
     let storage = InMemoryTreeStorage::empty();
-    let cache = PersistableFileCache::new(
+    let cache = FileCacheMap::new(
         sorted_tree::prolly_tree_editable_node::EditableNode::new(),
         &storage,
     );
@@ -66,7 +66,7 @@ async fn test_require_miss_and_hit() {
 #[test_log::test(tokio::test)]
 async fn test_download_error() {
     let storage = InMemoryTreeStorage::empty();
-    let cache = PersistableFileCache::new(
+    let cache = FileCacheMap::new(
         sorted_tree::prolly_tree_editable_node::EditableNode::new(),
         &storage,
     );
@@ -98,7 +98,7 @@ async fn test_download_error() {
 #[test_log::test(tokio::test)]
 async fn test_save_and_load_empty() {
     let storage = InMemoryTreeStorage::empty();
-    let original_cache = PersistableFileCache::new(
+    let original_cache = FileCacheMap::new(
         sorted_tree::prolly_tree_editable_node::EditableNode::new(),
         &storage,
     );
@@ -111,7 +111,7 @@ async fn test_save_and_load_empty() {
         ))
         .unwrap()
     );
-    let cache_loaded = PersistableFileCache::load(&cache_saved_reference, &storage)
+    let cache_loaded = FileCacheMap::load(&cache_saved_reference, &storage)
         .await
         .unwrap();
     assert_eq!(0, cache_loaded.number_of_entries().await.unwrap());
@@ -120,7 +120,7 @@ async fn test_save_and_load_empty() {
 #[test_log::test(tokio::test)]
 async fn test_save_and_load_non_empty() {
     let storage = InMemoryTreeStorage::empty();
-    let original_cache = PersistableFileCache::new(
+    let original_cache = FileCacheMap::new(
         sorted_tree::prolly_tree_editable_node::EditableNode::new(),
         &storage,
     );
@@ -167,7 +167,7 @@ async fn test_save_and_load_non_empty() {
         ))
         .unwrap()
     );
-    let cache_loaded = PersistableFileCache::load(&cache_saved_reference, &storage)
+    let cache_loaded = FileCacheMap::load(&cache_saved_reference, &storage)
         .await
         .unwrap();
     assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
@@ -218,8 +218,8 @@ impl UpdateRoot for PersistentSaveAndLoadNonEmptyUpdateRoot {
 async fn test_persistent_save_and_load_non_empty() {
     let storage = InMemoryTreeStorage::empty();
     let update_root = PersistentSaveAndLoadNonEmptyUpdateRoot::new();
-    let original_cache = PersistentFileCache::new(
-        PersistableFileCache::new(
+    let original_cache = PersistentFileCacheMap::new(
+        FileCacheMap::new(
             sorted_tree::prolly_tree_editable_node::EditableNode::new(),
             &storage,
         ),
@@ -271,8 +271,8 @@ async fn test_persistent_save_and_load_non_empty() {
         ))
         .unwrap()
     );
-    let cache_loaded = PersistentFileCache::new(
-        PersistableFileCache::load(&cache_saved_reference, &storage)
+    let cache_loaded = PersistentFileCacheMap::new(
+        FileCacheMap::load(&cache_saved_reference, &storage)
             .await
             .unwrap(),
         &storage,

--- a/dogbox/dropbox_importer/src/importer.rs
+++ b/dogbox/dropbox_importer/src/importer.rs
@@ -189,7 +189,7 @@ impl<'t> DropboxImporter<'t> {
         Ok(())
     }
 
-    async fn import_directory_entry(
+    pub async fn import_directory_entry(
         &self,
         from_directory: &str,
         entry: &DropboxFolderEntry,
@@ -221,7 +221,7 @@ impl<'t> DropboxImporter<'t> {
                 match import_file(
                     from_directory,
                     &entry.name,
-                    &metadata,
+                    metadata,
                     into_directory,
                     self.storage.clone(),
                     self.dropbox_api,

--- a/dogbox/dropbox_importer/src/importer.rs
+++ b/dogbox/dropbox_importer/src/importer.rs
@@ -126,7 +126,7 @@ impl<'t> DropboxImporter<'t> {
         }
     }
 
-    async fn import_folder(
+    async fn import_directory(
         &self,
         from_directory: &str,
         folder_name_raw: &str,
@@ -201,7 +201,7 @@ impl<'t> DropboxImporter<'t> {
             DropboxFolderEntryKind::Folder => {
                 info!("Folder entry: {}", entry.name);
                 match self
-                    .import_folder(from_directory, &entry.name, into_directory)
+                    .import_directory(from_directory, &entry.name, into_directory)
                     .await?
                 {
                     ImportFolderOutcome::Success => {

--- a/dogbox/dropbox_importer/src/importer.rs
+++ b/dogbox/dropbox_importer/src/importer.rs
@@ -7,10 +7,12 @@ use crate::{
 };
 use astraea::storage::{LoadStoreTree, StrongReference};
 use dogbox_tree::serialization::{FileName, FileNameError};
-use dogbox_tree_editor::{FileCreationMode, NormalizedPath, OpenDirectory};
+use dogbox_tree_editor::{
+    FileCreationMode, NormalizedPath, OpenDirectory, WallClock, DEFAULT_WRITE_BUFFER_IN_BLOCKS,
+};
 use futures::StreamExt;
 use relative_path::RelativePath;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tracing::{error, info, warn};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -258,4 +260,43 @@ impl<'t> DropboxImporter<'t> {
             }
         }
     }
+}
+
+pub async fn import_directory(
+    from_directory: &str,
+    storage: Arc<dyn LoadStoreTree + Send + Sync>,
+    clock: WallClock,
+    dropbox_api: &(dyn DropboxApi + Send + Sync),
+    download_cache: &dyn FileCache,
+) -> std::io::Result<Arc<OpenDirectory>> {
+    let open_directory = Arc::new(
+        OpenDirectory::create_directory(
+            PathBuf::new(),
+            storage.clone(),
+            clock.clone(),
+            DEFAULT_WRITE_BUFFER_IN_BLOCKS,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to create root directory in storage: {e}");
+            std::io::Error::other(format!("Failed to create root directory in storage: {e}"))
+        })?,
+    );
+    let empty_directory_reference = open_directory.latest_reference();
+    let importer = DropboxImporter::new(
+        storage,
+        &empty_directory_reference,
+        dropbox_api,
+        download_cache,
+    );
+    importer
+        .import_directory_impl(from_directory, &open_directory)
+        .await?;
+    open_directory.request_save().await.map_err(|e| {
+        std::io::Error::other(format!(
+            "Failed to save directory imported from {}: {e}",
+            from_directory
+        ))
+    })?;
+    Ok(open_directory)
 }

--- a/dogbox/dropbox_importer/src/importer.rs
+++ b/dogbox/dropbox_importer/src/importer.rs
@@ -1,6 +1,6 @@
 use crate::{
     dropbox_api::{
-        join_dropbox_path, parse_sha256_hex, DropboxApi, DropboxFileMetaData,
+        join_dropbox_path, parse_sha256_hex, DropboxApi, DropboxFileMetaData, DropboxFolderEntry,
         DropboxFolderEntryKind, Sha256Digest,
     },
     file_cache::FileCache,
@@ -183,63 +183,79 @@ impl<'t> DropboxImporter<'t> {
         let mut folder_entries = self.dropbox_api.list_folder(from_directory).await?;
         while let Some(entry_result) = folder_entries.next().await {
             let entry = entry_result?;
-            match entry.kind {
-                DropboxFolderEntryKind::Folder => {
-                    info!("Folder entry: {}", entry.name);
-                    match self
-                        .import_folder(from_directory, &entry.name, into_directory)
-                        .await?
-                    {
-                        ImportFolderOutcome::Success => {
-                            info!("Successfully imported folder {}", entry.name);
-                        }
-                        ImportFolderOutcome::UnsupportedFileName(e) => {
-                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                            warn!(
-                                "Skipping folder {} due to unsupported folder name: {e}",
-                                entry.name
-                            );
-                        }
+            self.import_directory_entry(from_directory, &entry, into_directory)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn import_directory_entry(
+        &self,
+        from_directory: &str,
+        entry: &DropboxFolderEntry,
+        into_directory: &Arc<OpenDirectory>,
+    ) -> std::io::Result<()> {
+        match &entry.kind {
+            DropboxFolderEntryKind::Folder => {
+                info!("Folder entry: {}", entry.name);
+                match self
+                    .import_folder(from_directory, &entry.name, into_directory)
+                    .await?
+                {
+                    ImportFolderOutcome::Success => {
+                        info!("Successfully imported folder {}", entry.name);
+                        Ok(())
+                    }
+                    ImportFolderOutcome::UnsupportedFileName(e) => {
+                        // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                        warn!(
+                            "Skipping folder {} due to unsupported folder name: {e}",
+                            entry.name
+                        );
+                        Ok(())
                     }
                 }
-                DropboxFolderEntryKind::File { metadata } => {
-                    info!("File entry: {}", entry.name);
-                    match import_file(
-                        from_directory,
-                        &entry.name,
-                        &metadata,
-                        into_directory,
-                        self.storage.clone(),
-                        self.dropbox_api,
-                        self.download_cache,
-                    )
-                    .await?
-                    {
-                        ImportFileOutcome::Success => {
-                            info!("Successfully imported file {}", entry.name);
-                        }
-                        ImportFileOutcome::UnsupportedFileName(e) => {
-                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                            warn!(
-                                "Skipping file {} due to unsupported file name: {e}",
-                                entry.name
-                            );
-                        }
-                        ImportFileOutcome::MissingContentHash => {
-                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                            warn!("Skipping file {} due to missing content hash", entry.name);
-                        }
-                        ImportFileOutcome::InvalidContentHash(content_hash_string) => {
-                            // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
-                            warn!(
-                                "Skipping file {} due to invalid content hash: {}",
-                                entry.name, content_hash_string
-                            );
-                        }
+            }
+            DropboxFolderEntryKind::File { metadata } => {
+                info!("File entry: {}", entry.name);
+                match import_file(
+                    from_directory,
+                    &entry.name,
+                    &metadata,
+                    into_directory,
+                    self.storage.clone(),
+                    self.dropbox_api,
+                    self.download_cache,
+                )
+                .await?
+                {
+                    ImportFileOutcome::Success => {
+                        info!("Successfully imported file {}", entry.name);
+                        Ok(())
+                    }
+                    ImportFileOutcome::UnsupportedFileName(e) => {
+                        // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                        warn!(
+                            "Skipping file {} due to unsupported file name: {e}",
+                            entry.name
+                        );
+                        Ok(())
+                    }
+                    ImportFileOutcome::MissingContentHash => {
+                        // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                        warn!("Skipping file {} due to missing content hash", entry.name);
+                        Ok(())
+                    }
+                    ImportFileOutcome::InvalidContentHash(content_hash_string) => {
+                        // TODO: return this information somehow to the caller so that they can decide what to do with it (e.g. show a warning to the user)
+                        warn!(
+                            "Skipping file {} due to invalid content hash: {}",
+                            entry.name, content_hash_string
+                        );
+                        Ok(())
                     }
                 }
             }
         }
-        Ok(())
     }
 }

--- a/dogbox/dropbox_importer/src/importer_tests.rs
+++ b/dogbox/dropbox_importer/src/importer_tests.rs
@@ -1,7 +1,9 @@
 use crate::{
-    dropbox_api::{DropboxApi, DropboxFileMetaData, DropboxFolderEntry, Sha256Digest},
+    dropbox_api::{
+        DropboxApi, DropboxFileMetaData, DropboxFolderEntry, DropboxFolderEntryKind, Sha256Digest,
+    },
     file_cache::{PersistableFileCache, PersistableFileCacheEntry, Sha256CacheKey},
-    importer::{import_file, ImportFileOutcome},
+    importer::{import_file, DropboxImporter, ImportFileOutcome},
 };
 use astraea::{
     in_memory_storage::InMemoryTreeStorage,
@@ -11,12 +13,13 @@ use astraea::{
 use async_trait::async_trait;
 use dogbox_tree_editor::{DigestStatus, OpenDirectory, OpenDirectoryStatus, OpenFileStats};
 use dropbox_sdk::async_routes::files;
+use futures::StreamExt;
 use std::{collections::BTreeMap, pin::Pin, sync::Arc};
 
-struct FakeDropboxApi {}
+struct UnreachableDropboxApi {}
 
 #[async_trait]
-impl DropboxApi for FakeDropboxApi {
+impl DropboxApi for UnreachableDropboxApi {
     async fn download_file(
         &self,
         _dropbox_file_path: &str,
@@ -24,7 +27,7 @@ impl DropboxApi for FakeDropboxApi {
         _dropbox_content_hash: &Sha256Digest,
         _storage: Arc<dyn LoadStoreTree + Send + Sync>,
     ) -> std::io::Result<(StrongReference, u64)> {
-        todo!()
+        unreachable!()
     }
 
     async fn list_folder(
@@ -33,7 +36,35 @@ impl DropboxApi for FakeDropboxApi {
     ) -> std::io::Result<
         Pin<Box<dyn futures::Stream<Item = std::io::Result<DropboxFolderEntry>> + Send>>,
     > {
-        todo!()
+        unreachable!()
+    }
+}
+
+struct FailingDropboxApi {}
+
+#[async_trait]
+impl DropboxApi for FailingDropboxApi {
+    async fn download_file(
+        &self,
+        _dropbox_file_path: &str,
+        _dropbox_file_rev: &files::Rev,
+        _dropbox_content_hash: &Sha256Digest,
+        _storage: Arc<dyn LoadStoreTree + Send + Sync>,
+    ) -> std::io::Result<(StrongReference, u64)> {
+        Err(std::io::Error::other(
+            "Simulated download failure",
+        ))
+    }
+
+    async fn list_folder(
+        &self,
+        _dropbox_folder_path: &str,
+    ) -> std::io::Result<
+        Pin<Box<dyn futures::Stream<Item = std::io::Result<DropboxFolderEntry>> + Send>>,
+    > {
+        Err(std::io::Error::other(
+            "Simulated folder listing failure",
+        ))
     }
 }
 
@@ -63,7 +94,7 @@ async fn test_import_file_missing_content_hash() {
         clock,
         1,
     ));
-    let dropbox_api = FakeDropboxApi {};
+    let dropbox_api = UnreachableDropboxApi {};
     let outcome = import_file(
         "/test",
         "file.txt",
@@ -95,4 +126,64 @@ async fn test_import_file_missing_content_hash() {
             modified,
         ),
     )
+}
+
+#[test_log::test(tokio::test)]
+async fn test_import_directory_entry() {
+    let storage = Arc::new(InMemoryTreeStorage::empty());
+    let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256CacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let download_cache = PersistableFileCache::new(download_cache_tree, &*storage);
+    let original_content_reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::empty(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let modified = clock();
+    let open_directory = Arc::new(OpenDirectory::new(
+        std::path::PathBuf::from("/"),
+        DigestStatus::new(original_content_reference.clone(), false),
+        BTreeMap::new(),
+        storage.clone(),
+        modified,
+        clock,
+        1,
+    ));
+    let dropbox_api = FailingDropboxApi {};
+    let importer = DropboxImporter::new(
+        storage.clone(),
+        &original_content_reference,
+        &dropbox_api,
+        &download_cache,
+    );
+    let error = importer
+        .import_directory_entry(
+            "/",
+            &DropboxFolderEntry {
+                name: "file.txt".to_string(),
+                kind: DropboxFolderEntryKind::File {
+                    metadata: DropboxFileMetaData {
+                        content_hash: Some(
+                            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+                                .to_string(),
+                        ),
+                        rev: "1".to_string(),
+                    },
+                },
+            },
+            &open_directory,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Failed to download /file.txt: Simulated download failure"
+    );
+    let mut entries = open_directory.read().await;
+    if entries.next().await.is_some() { panic!("Unexpected directory entry") }
 }

--- a/dogbox/dropbox_importer/src/importer_tests.rs
+++ b/dogbox/dropbox_importer/src/importer_tests.rs
@@ -3,7 +3,7 @@ use crate::{
         DropboxApi, DropboxFileMetaData, DropboxFolderEntry, DropboxFolderEntryKind, Sha256Digest,
     },
     file_cache::{FileCacheMap, PersistableFileCacheEntry, Sha256CacheKey},
-    importer::{import_file, DropboxImporter, ImportFileOutcome},
+    importer::{import_directory, import_file, DropboxImporter, ImportFileOutcome},
 };
 use astraea::{
     in_memory_storage::InMemoryTreeStorage,
@@ -125,7 +125,7 @@ async fn test_import_file_missing_content_hash() {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_import_directory_entry() {
+async fn test_import_directory_entry_dropbox_failure() {
     let storage = Arc::new(InMemoryTreeStorage::empty());
     let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
     let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
@@ -180,6 +180,43 @@ async fn test_import_directory_entry() {
         error.to_string(),
         "Failed to download /file.txt: Simulated download failure"
     );
+    let mut entries = open_directory.read().await;
+    if entries.next().await.is_some() {
+        panic!("Unexpected directory entry")
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_import_directory_dropbox_failure() {
+    let storage = Arc::new(InMemoryTreeStorage::empty());
+    let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256CacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage);
+    let original_content_reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::empty(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let modified = clock();
+    let open_directory = Arc::new(OpenDirectory::new(
+        std::path::PathBuf::from("/"),
+        DigestStatus::new(original_content_reference.clone(), false),
+        BTreeMap::new(),
+        storage.clone(),
+        modified,
+        clock.clone(),
+        1,
+    ));
+    let dropbox_api = FailingDropboxApi {};
+    let error = import_directory("/", storage.clone(), clock, &dropbox_api, &download_cache)
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "Simulated folder listing failure");
     let mut entries = open_directory.read().await;
     if entries.next().await.is_some() {
         panic!("Unexpected directory entry")

--- a/dogbox/dropbox_importer/src/importer_tests.rs
+++ b/dogbox/dropbox_importer/src/importer_tests.rs
@@ -2,7 +2,7 @@ use crate::{
     dropbox_api::{
         DropboxApi, DropboxFileMetaData, DropboxFolderEntry, DropboxFolderEntryKind, Sha256Digest,
     },
-    file_cache::{PersistableFileCache, PersistableFileCacheEntry, Sha256CacheKey},
+    file_cache::{FileCacheMap, PersistableFileCacheEntry, Sha256CacheKey},
     importer::{import_file, DropboxImporter, ImportFileOutcome},
 };
 use astraea::{
@@ -51,9 +51,7 @@ impl DropboxApi for FailingDropboxApi {
         _dropbox_content_hash: &Sha256Digest,
         _storage: Arc<dyn LoadStoreTree + Send + Sync>,
     ) -> std::io::Result<(StrongReference, u64)> {
-        Err(std::io::Error::other(
-            "Simulated download failure",
-        ))
+        Err(std::io::Error::other("Simulated download failure"))
     }
 
     async fn list_folder(
@@ -62,9 +60,7 @@ impl DropboxApi for FailingDropboxApi {
     ) -> std::io::Result<
         Pin<Box<dyn futures::Stream<Item = std::io::Result<DropboxFolderEntry>> + Send>>,
     > {
-        Err(std::io::Error::other(
-            "Simulated folder listing failure",
-        ))
+        Err(std::io::Error::other("Simulated folder listing failure"))
     }
 }
 
@@ -76,7 +72,7 @@ async fn test_import_file_missing_content_hash() {
         Sha256CacheKey,
         PersistableFileCacheEntry,
     >::new();
-    let download_cache = PersistableFileCache::new(download_cache_tree, &*storage);
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage);
     let original_content_reference = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
@@ -136,7 +132,7 @@ async fn test_import_directory_entry() {
         Sha256CacheKey,
         PersistableFileCacheEntry,
     >::new();
-    let download_cache = PersistableFileCache::new(download_cache_tree, &*storage);
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage);
     let original_content_reference = storage
         .store_tree(&HashedTree::from(Arc::new(Tree::new(
             TreeBlob::empty(),
@@ -185,5 +181,7 @@ async fn test_import_directory_entry() {
         "Failed to download /file.txt: Simulated download failure"
     );
     let mut entries = open_directory.read().await;
-    if entries.next().await.is_some() { panic!("Unexpected directory entry") }
+    if entries.next().await.is_some() {
+        panic!("Unexpected directory entry")
+    }
 }

--- a/dogbox/dropbox_importer/src/lib.rs
+++ b/dogbox/dropbox_importer/src/lib.rs
@@ -1,9 +1,3 @@
-use crate::{dropbox_api::DropboxApi, file_cache::FileCache, importer::DropboxImporter};
-use astraea::storage::LoadStoreTree;
-use dogbox_tree_editor::{OpenDirectory, WallClock, DEFAULT_WRITE_BUFFER_IN_BLOCKS};
-use std::{path::PathBuf, sync::Arc};
-use tracing::error;
-
 mod dropbox_content_hash;
 
 #[cfg(test)]
@@ -23,42 +17,3 @@ pub mod importer;
 
 #[cfg(test)]
 mod importer_tests;
-
-pub async fn import_directory(
-    from_directory: &str,
-    storage: Arc<dyn LoadStoreTree + Send + Sync>,
-    clock: WallClock,
-    dropbox_api: &(dyn DropboxApi + Send + Sync),
-    download_cache: &dyn FileCache,
-) -> std::io::Result<Arc<OpenDirectory>> {
-    let open_directory = Arc::new(
-        OpenDirectory::create_directory(
-            PathBuf::new(),
-            storage.clone(),
-            clock.clone(),
-            DEFAULT_WRITE_BUFFER_IN_BLOCKS,
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to create root directory in storage: {e}");
-            std::io::Error::other(format!("Failed to create root directory in storage: {e}"))
-        })?,
-    );
-    let empty_directory_reference = open_directory.latest_reference();
-    let importer = DropboxImporter::new(
-        storage,
-        &empty_directory_reference,
-        dropbox_api,
-        download_cache,
-    );
-    importer
-        .import_directory_impl(from_directory, &open_directory)
-        .await?;
-    open_directory.request_save().await.map_err(|e| {
-        std::io::Error::other(format!(
-            "Failed to save directory imported from {}: {e}",
-            from_directory
-        ))
-    })?;
-    Ok(open_directory)
-}

--- a/system_tests/src/dropbox_importer_tests.rs
+++ b/system_tests/src/dropbox_importer_tests.rs
@@ -8,6 +8,7 @@ use dogbox_tree_editor::{FileCreationMode, OpenDirectory, OpenFile};
 use dropbox_importer::{
     dropbox_api::RealDropboxApi,
     file_cache::{FileCacheMap, PersistableFileCacheEntry, Sha256CacheKey},
+    importer::import_directory,
 };
 use dropbox_sdk::{default_async_client::UserAuthDefaultClient, oauth2::Authorization};
 use futures::StreamExt;
@@ -167,7 +168,7 @@ async fn verify_import(
         PersistableFileCacheEntry,
     >::new();
     let download_cache = FileCacheMap::new(download_cache_tree, &*storage);
-    let open_directory = dropbox_importer::import_directory(
+    let open_directory = import_directory(
         dropbox_test_directory,
         storage.clone(),
         clock,

--- a/system_tests/src/dropbox_importer_tests.rs
+++ b/system_tests/src/dropbox_importer_tests.rs
@@ -7,7 +7,7 @@ use dogbox_tree::serialization::{DirectoryEntryKind, FileName};
 use dogbox_tree_editor::{FileCreationMode, OpenDirectory, OpenFile};
 use dropbox_importer::{
     dropbox_api::RealDropboxApi,
-    file_cache::{PersistableFileCache, PersistableFileCacheEntry, Sha256CacheKey},
+    file_cache::{FileCacheMap, PersistableFileCacheEntry, Sha256CacheKey},
 };
 use dropbox_sdk::{default_async_client::UserAuthDefaultClient, oauth2::Authorization};
 use futures::StreamExt;
@@ -166,7 +166,7 @@ async fn verify_import(
         Sha256CacheKey,
         PersistableFileCacheEntry,
     >::new();
-    let download_cache = PersistableFileCache::new(download_cache_tree, &*storage);
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage);
     let open_directory = dropbox_importer::import_directory(
         dropbox_test_directory,
         storage.clone(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing a single Dropbox folder entry into an open directory (in addition to full directory imports).
* **Refactor**
  * Reworked the Dropbox import directory listing flow to process folder entries via a dedicated per-entry handler.
  * Updated the download/content cache abstractions used during Dropbox imports.
* **Tests**
  * Updated unit and integration tests to use the new cache types and the new single-entry import path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->