### PR TITLE
Importer test coverage

### DIFF
--- a/dogbox/dropbox_importer/src/dropbox_api.rs
+++ b/dogbox/dropbox_importer/src/dropbox_api.rs
@@ -285,7 +285,6 @@ pub struct DropboxFolderEntry {
 
 pub struct DownloadRequest {
     pub dropbox_rev: files::Rev,
-    pub dropbox_content_hash: Sha256Digest,
     pub offset: u64,
     pub length_to_download: u64,
 }

--- a/dogbox/dropbox_importer/src/file_cache.rs
+++ b/dogbox/dropbox_importer/src/file_cache.rs
@@ -51,7 +51,7 @@ pub trait FileCache: Send + Sync {
     async fn require<'t>(
         &'t self,
         chunk_cache_key: &Sha256ChunkCacheKey,
-        download_file: Box<
+        download_file_chunk: Box<
             dyn FnOnce() -> std::pin::Pin<
                     Box<
                         dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
@@ -167,7 +167,7 @@ impl<'a> FileCacheMap<'a> {
     async fn require_impl(
         &'a self,
         chunk_cache_key: &Sha256ChunkCacheKey,
-        download_file: DownloadFileCallback<'a>,
+        download_file_chunk: DownloadFileCallback<'a>,
     ) -> std::io::Result<(StrongReference, u64)> {
         // TODO: don't hold the lock during the download
         let mut entries_locked = self.entries.lock().await;
@@ -184,7 +184,7 @@ impl<'a> FileCacheMap<'a> {
             }
             None => {
                 info!("Cache miss for chunk cache key {}", chunk_cache_key);
-                let (content_reference, content_size) = download_file().await?;
+                let (content_reference, content_size) = download_file_chunk().await?;
                 let new_entry = PersistableFileCacheEntry {
                     content_reference: content_reference.clone(),
                     content_size,
@@ -208,7 +208,7 @@ impl FileCache for FileCacheMap<'_> {
     async fn require<'t>(
         &'t self,
         chunk_cache_key: &Sha256ChunkCacheKey,
-        download_file: Box<
+        download_file_chunk: Box<
             dyn FnOnce() -> std::pin::Pin<
                     Box<
                         dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
@@ -220,7 +220,7 @@ impl FileCache for FileCacheMap<'_> {
         >,
     ) -> std::io::Result<(StrongReference, u64)> {
         // We call this function because code coverage doesn't work for async_traits.
-        self.require_impl(chunk_cache_key, download_file).await
+        self.require_impl(chunk_cache_key, download_file_chunk).await
     }
 
     fn chunk_size(&self) -> u64 {
@@ -257,11 +257,11 @@ impl<'a> PersistentFileCacheMap<'a> {
     async fn require_impl(
         &'a self,
         chunk_cache_key: &Sha256ChunkCacheKey,
-        download_file: DownloadFileCallback<'a>,
+        download_file_chunk: DownloadFileCallback<'a>,
     ) -> std::io::Result<(StrongReference, u64)> {
         let success = self
             .original_cache
-            .require(chunk_cache_key, download_file)
+            .require(chunk_cache_key, download_file_chunk)
             .await?;
         // TODO: only save and update root if the cache was modified (i.e. if it was a cache miss)
         let saved = self
@@ -288,7 +288,7 @@ impl FileCache for PersistentFileCacheMap<'_> {
     async fn require<'t>(
         &'t self,
         chunk_cache_key: &Sha256ChunkCacheKey,
-        download_file: Box<
+        download_file_chunk: Box<
             dyn FnOnce() -> std::pin::Pin<
                     Box<
                         dyn std::future::Future<Output = std::io::Result<(StrongReference, u64)>>
@@ -300,7 +300,7 @@ impl FileCache for PersistentFileCacheMap<'_> {
         >,
     ) -> std::io::Result<(StrongReference, u64)> {
         // We call this function because code coverage doesn't work for async_traits.
-        self.require_impl(chunk_cache_key, download_file).await
+        self.require_impl(chunk_cache_key, download_file_chunk).await
     }
 
     fn chunk_size(&self) -> u64 {

--- a/dogbox/dropbox_importer/src/file_cache.rs
+++ b/dogbox/dropbox_importer/src/file_cache.rs
@@ -220,7 +220,8 @@ impl FileCache for FileCacheMap<'_> {
         >,
     ) -> std::io::Result<(StrongReference, u64)> {
         // We call this function because code coverage doesn't work for async_traits.
-        self.require_impl(chunk_cache_key, download_file_chunk).await
+        self.require_impl(chunk_cache_key, download_file_chunk)
+            .await
     }
 
     fn chunk_size(&self) -> u64 {
@@ -300,7 +301,8 @@ impl FileCache for PersistentFileCacheMap<'_> {
         >,
     ) -> std::io::Result<(StrongReference, u64)> {
         // We call this function because code coverage doesn't work for async_traits.
-        self.require_impl(chunk_cache_key, download_file_chunk).await
+        self.require_impl(chunk_cache_key, download_file_chunk)
+            .await
     }
 
     fn chunk_size(&self) -> u64 {

--- a/dogbox/dropbox_importer/src/file_cache_tests.rs
+++ b/dogbox/dropbox_importer/src/file_cache_tests.rs
@@ -8,6 +8,7 @@ use astraea::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::future::join_all;
 use pretty_assertions::assert_eq;
 use std::{pin::Pin, sync::Arc};
 
@@ -293,6 +294,93 @@ async fn test_persistent_save_and_load_non_empty() {
     );
     assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
     // the entry should still exist
+    {
+        let (result_reference, result_length) = cache_loaded
+            .require(&chunk_cache_key, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+        assert_eq!(
+            update_root.current_value().await,
+            Some(cache_saved_reference)
+        );
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_persistent_file_cache_require_same_chunk_multiple_times() {
+    // This test is to ensure that if multiple concurrent calls to require() are made for the same chunk,
+    // only one of them will actually download the chunk, and the others will wait for it to finish and then return the same result.
+    let storage = InMemoryTreeStorage::empty();
+    let update_root = PersistentSaveAndLoadNonEmptyUpdateRoot::new();
+    let chunk_size = DEFAULT_CHUNK_SIZE;
+    let original_cache = PersistentFileCacheMap::new(
+        FileCacheMap::new(
+            sorted_tree::prolly_tree_editable_node::EditableNode::new(),
+            &storage,
+            chunk_size,
+        ),
+        &storage,
+        &update_root,
+        "test_root".to_string(),
+    );
+    let reference = storage
+        .store_tree(&HashedTree::from(Arc::new(Tree::new(
+            TreeBlob::try_from(Bytes::new()).unwrap(),
+            TreeChildren::empty(),
+        ))))
+        .await
+        .unwrap();
+    let length = 0u64;
+    let chunk_cache_key = Sha256ChunkCacheKey::new([0u8; 32], 0);
+    let download_file_counter = Arc::new(tokio::sync::Mutex::new(0));
+    let make_download_file = || {
+        let reference = reference.clone();
+        let download_file_counter = download_file_counter.clone();
+        Box::new(move || {
+            Box::pin(async move {
+                let mut counter = download_file_counter.lock().await;
+                *counter += 1;
+                Ok((reference, length))
+            }) as Pin<Box<dyn std::future::Future<Output = Result<(_, u64), _>> + Send>>
+        })
+    };
+    assert_eq!(0, original_cache.number_of_entries().await.unwrap());
+    assert_eq!(0, *download_file_counter.lock().await);
+    assert_eq!(None, update_root.current_value().await);
+    const CONCURRENCY: usize = 10;
+    join_all((0..CONCURRENCY).map(|_| async {
+        let (result_reference, result_length) = original_cache
+            .require(&chunk_cache_key, make_download_file())
+            .await
+            .unwrap();
+        assert_eq!(result_reference, reference);
+        assert_eq!(result_length, length);
+        assert_eq!(1, original_cache.number_of_entries().await.unwrap());
+        assert_eq!(1, *download_file_counter.lock().await);
+    }))
+    .await;
+    let cache_saved_reference = update_root.current_value().await.unwrap();
+    assert_eq!(
+        cache_saved_reference.digest(),
+        &BlobDigest::parse_hex_string(concat!(
+            "4b2bd26620b490261ff1e76b42d5504aa11f9bdfdaea670e871883460765b799",
+            "4df19e9dbb9661549e19755f76bd6b4bd1a4802454ddeca0e4da3a2ffc7474ae"
+        ))
+        .unwrap()
+    );
+    let cache_loaded = PersistentFileCacheMap::new(
+        FileCacheMap::load(&cache_saved_reference, &storage, chunk_size)
+            .await
+            .unwrap(),
+        &storage,
+        &update_root,
+        "test_root".to_string(),
+    );
+    assert_eq!(1, cache_loaded.number_of_entries().await.unwrap());
     {
         let (result_reference, result_length) = cache_loaded
             .require(&chunk_cache_key, make_download_file())

--- a/dogbox/dropbox_importer/src/importer.rs
+++ b/dogbox/dropbox_importer/src/importer.rs
@@ -88,7 +88,6 @@ async fn download_file_in_chunks(
                                 &dropbox_file_path,
                                 &DownloadRequest {
                                     dropbox_rev: dropbox_file_rev,
-                                    dropbox_content_hash: *content_hash,
                                     offset: downloaded_bytes,
                                     length_to_download: chunk_size,
                                 },

--- a/dogbox/dropbox_importer/src/importer_tests.rs
+++ b/dogbox/dropbox_importer/src/importer_tests.rs
@@ -111,17 +111,6 @@ impl SucceedingDropboxApiDirectory {
                         )));
                     }
                     assert_eq!(download_request.dropbox_rev, file_content.rev);
-                    let mut hasher = crate::dropbox_content_hash::DropboxContentHasher::new();
-                    hasher.update(&file_content.content);
-                    let calculated_dropbox_content_hash = hasher.finalize();
-                    if download_request.dropbox_content_hash != calculated_dropbox_content_hash {
-                        return Err(std::io::Error::other(format!(
-                            "Content hash mismatch for file {}: expected {}, got {}",
-                            dropbox_file_path,
-                            format_dropbox_content_hash(&download_request.dropbox_content_hash),
-                            format_dropbox_content_hash(&calculated_dropbox_content_hash)
-                        )));
-                    }
                     let empty_file_reference = TreeEditor::store_empty_file(storage.clone())
                         .await
                         .map_err(|e| {
@@ -400,7 +389,6 @@ async fn test_import_file_content_hash_mismatch() {
     assert_eq!(
         error.to_string(),
         concat!(
-            "Failed to download chunk 0 of /file.txt: ",
             "Content hash mismatch for file /file.txt: expected ",
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, got ",
             "70bc18bef5ae66b72d1995f8db90a583a60d77b4066e4653f1cead613025861c"
@@ -422,7 +410,9 @@ async fn test_import_file_content_hash_mismatch() {
             modified,
         ),
     );
-    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
+    // The content hash can only be verified after assembling the cache chunks into a file,
+    // so the cache should still contain the downloaded chunk.
+    assert_eq!(1, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]

--- a/dogbox/dropbox_importer/src/importer_tests.rs
+++ b/dogbox/dropbox_importer/src/importer_tests.rs
@@ -350,6 +350,82 @@ async fn test_import_file_missing_content_hash() {
 }
 
 #[test_log::test(tokio::test)]
+async fn test_import_file_content_hash_mismatch() {
+    let storage = Arc::new(InMemoryTreeStorage::empty());
+    let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256ChunkCacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let chunk_size = DEFAULT_CHUNK_SIZE;
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage, chunk_size);
+    let modified = clock();
+    let open_directory = Arc::new(
+        OpenDirectory::create_directory(std::path::PathBuf::from("/"), storage.clone(), clock, 1)
+            .await
+            .unwrap(),
+    );
+    let file_name = "file.txt";
+    let rev = "1";
+    let actual_content = Bytes::from_static(b"Hello");
+    let dropbox_api = SucceedingDropboxApi::new(SucceedingDropboxApiDirectory {
+        entries: BTreeMap::from([(
+            file_name.to_string(),
+            SucceedingDropboxApiDirectoryEntry::File(SucceedingDropboxApiFileContentWithRev {
+                content: actual_content.clone(),
+                rev: rev.to_string(),
+            }),
+        )]),
+    });
+    let content_hash = format_dropbox_content_hash(&{
+        let hasher = DropboxContentHasher::new();
+        // not hashing the actual content to simulate a content hash mismatch
+        hasher.finalize()
+    });
+    let error = import_file(
+        "/",
+        file_name,
+        &DropboxFileMetaData {
+            content_hash: Some(content_hash),
+            rev: rev.to_string(),
+            size: actual_content.len() as u64,
+        },
+        &open_directory,
+        storage.clone(),
+        &dropbox_api,
+        &download_cache,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        concat!(
+            "Failed to download chunk 0 of /file.txt: ",
+            "Content hash mismatch for file /file.txt: expected ",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, got ",
+            "70bc18bef5ae66b72d1995f8db90a583a60d77b4066e4653f1cead613025861c"
+        )
+    );
+    let status = open_directory
+        .request_save()
+        .await
+        .expect("Failed to save directory");
+    // the digest doesn't really matter here
+    let new_reference = status.digest.last_known_digest.clone();
+    assert_eq!(
+        status,
+        OpenDirectoryStatus::new(
+            DigestStatus::new(new_reference, true),
+            1,
+            0,
+            OpenFileStats::new(0, 0, 0, 0, 0),
+            modified,
+        ),
+    );
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
+}
+
+#[test_log::test(tokio::test)]
 async fn test_import_directory_entry_dropbox_failure() {
     let storage = Arc::new(InMemoryTreeStorage::empty());
     let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);

--- a/dogbox/dropbox_importer/src/importer_tests.rs
+++ b/dogbox/dropbox_importer/src/importer_tests.rs
@@ -345,7 +345,8 @@ async fn test_import_file_missing_content_hash() {
             OpenFileStats::new(0, 0, 0, 0, 0),
             modified,
         ),
-    )
+    );
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -400,6 +401,7 @@ async fn test_import_directory_entry_dropbox_failure() {
     if entries.next().await.is_some() {
         panic!("Unexpected directory entry")
     }
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -465,6 +467,7 @@ async fn test_import_directory_entry_file_success_small() {
         )]),
     )
     .await;
+    assert_eq!(1, download_cache.number_of_entries().await.unwrap());
 }
 
 fn random_bytes(len: usize) -> Bytes {
@@ -540,6 +543,7 @@ async fn test_import_directory_entry_file_success_large() {
         )]),
     )
     .await;
+    assert_eq!(3, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -587,6 +591,7 @@ async fn test_import_directory_entry_file_unsupported_name() {
         .await
         .unwrap();
     assert_directory_contents(&open_directory, &BTreeMap::new()).await;
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -632,6 +637,7 @@ async fn test_import_directory_entry_file_missing_content_hash() {
         .await
         .unwrap();
     assert_directory_contents(&open_directory, &BTreeMap::new()).await;
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -677,6 +683,7 @@ async fn test_import_directory_entry_file_invalid_content_hash() {
         .await
         .unwrap();
     assert_directory_contents(&open_directory, &BTreeMap::new()).await;
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -728,6 +735,7 @@ async fn test_import_directory_entry_subdirectory_success() {
         )]),
     )
     .await;
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -759,6 +767,7 @@ async fn test_import_directory_dropbox_failure() {
     if entries.next().await.is_some() {
         panic!("Unexpected directory entry")
     }
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -797,6 +806,7 @@ async fn test_import_directory_entry_subdirectory_unsupported_name() {
         .await
         .unwrap();
     assert_directory_contents(&open_directory, &BTreeMap::new()).await;
+    assert_eq!(0, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -846,6 +856,7 @@ async fn test_import_directory_simple_success() {
         ]),
     )
     .await;
+    assert_eq!(1, download_cache.number_of_entries().await.unwrap());
 }
 
 #[test_log::test(tokio::test)]
@@ -928,4 +939,5 @@ async fn test_import_directory_recursive_success() {
         ]),
     )
     .await;
+    assert_eq!(2, download_cache.number_of_entries().await.unwrap());
 }

--- a/dogbox/dropbox_importer/src/importer_tests.rs
+++ b/dogbox/dropbox_importer/src/importer_tests.rs
@@ -543,6 +543,143 @@ async fn test_import_directory_entry_file_success_large() {
 }
 
 #[test_log::test(tokio::test)]
+async fn test_import_directory_entry_file_unsupported_name() {
+    let storage = Arc::new(InMemoryTreeStorage::empty());
+    let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256ChunkCacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let chunk_size = DEFAULT_CHUNK_SIZE;
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage, chunk_size);
+    let open_directory = Arc::new(
+        OpenDirectory::create_directory(std::path::PathBuf::from("/"), storage.clone(), clock, 1)
+            .await
+            .unwrap(),
+    );
+    let empty_directory_reference = open_directory.latest_reference();
+    let dropbox_api = FailingDropboxApi {};
+    let importer = DropboxImporter::new(
+        storage.clone(),
+        &empty_directory_reference,
+        &dropbox_api,
+        &download_cache,
+    );
+    // TODO: expect an error to be reported
+    importer
+        .import_directory_entry(
+            "/",
+            &DropboxFolderEntry {
+                name: ">".to_string(),
+                kind: DropboxFolderEntryKind::File {
+                    metadata: DropboxFileMetaData {
+                        content_hash: Some(format_dropbox_content_hash(&{
+                            let hasher = DropboxContentHasher::new();
+                            hasher.finalize()
+                        })),
+                        rev: "1".to_string(),
+                        size: 0,
+                    },
+                },
+            },
+            &open_directory,
+        )
+        .await
+        .unwrap();
+    assert_directory_contents(&open_directory, &BTreeMap::new()).await;
+}
+
+#[test_log::test(tokio::test)]
+async fn test_import_directory_entry_file_missing_content_hash() {
+    let storage = Arc::new(InMemoryTreeStorage::empty());
+    let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256ChunkCacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let chunk_size = DEFAULT_CHUNK_SIZE;
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage, chunk_size);
+    let open_directory = Arc::new(
+        OpenDirectory::create_directory(std::path::PathBuf::from("/"), storage.clone(), clock, 1)
+            .await
+            .unwrap(),
+    );
+    let empty_directory_reference = open_directory.latest_reference();
+    let dropbox_api = FailingDropboxApi {};
+    let importer = DropboxImporter::new(
+        storage.clone(),
+        &empty_directory_reference,
+        &dropbox_api,
+        &download_cache,
+    );
+    // TODO: expect an error to be reported
+    importer
+        .import_directory_entry(
+            "/",
+            &DropboxFolderEntry {
+                name: "file.txt".to_string(),
+                kind: DropboxFolderEntryKind::File {
+                    metadata: DropboxFileMetaData {
+                        // The content hash is missing, which should trigger the importer to report an error or handle it accordingly.
+                        content_hash: None,
+                        rev: "1".to_string(),
+                        size: 0,
+                    },
+                },
+            },
+            &open_directory,
+        )
+        .await
+        .unwrap();
+    assert_directory_contents(&open_directory, &BTreeMap::new()).await;
+}
+
+#[test_log::test(tokio::test)]
+async fn test_import_directory_entry_file_invalid_content_hash() {
+    let storage = Arc::new(InMemoryTreeStorage::empty());
+    let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256ChunkCacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let chunk_size = DEFAULT_CHUNK_SIZE;
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage, chunk_size);
+    let open_directory = Arc::new(
+        OpenDirectory::create_directory(std::path::PathBuf::from("/"), storage.clone(), clock, 1)
+            .await
+            .unwrap(),
+    );
+    let empty_directory_reference = open_directory.latest_reference();
+    let dropbox_api = FailingDropboxApi {};
+    let importer = DropboxImporter::new(
+        storage.clone(),
+        &empty_directory_reference,
+        &dropbox_api,
+        &download_cache,
+    );
+    // TODO: expect an error to be reported
+    importer
+        .import_directory_entry(
+            "/",
+            &DropboxFolderEntry {
+                name: "file.txt".to_string(),
+                kind: DropboxFolderEntryKind::File {
+                    metadata: DropboxFileMetaData {
+                        // The content hash is invalid, which should trigger the importer to report an error or handle it accordingly.
+                        content_hash: Some("invalid".to_string()),
+                        rev: "1".to_string(),
+                        size: 0,
+                    },
+                },
+            },
+            &open_directory,
+        )
+        .await
+        .unwrap();
+    assert_directory_contents(&open_directory, &BTreeMap::new()).await;
+}
+
+#[test_log::test(tokio::test)]
 async fn test_import_directory_entry_subdirectory_success() {
     let storage = Arc::new(InMemoryTreeStorage::empty());
     let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
@@ -622,6 +759,44 @@ async fn test_import_directory_dropbox_failure() {
     if entries.next().await.is_some() {
         panic!("Unexpected directory entry")
     }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_import_directory_entry_subdirectory_unsupported_name() {
+    let storage = Arc::new(InMemoryTreeStorage::empty());
+    let clock = Arc::new(|| std::time::SystemTime::UNIX_EPOCH);
+    let download_cache_tree = sorted_tree::prolly_tree_editable_node::EditableNode::<
+        Sha256ChunkCacheKey,
+        PersistableFileCacheEntry,
+    >::new();
+    let chunk_size = DEFAULT_CHUNK_SIZE;
+    let download_cache = FileCacheMap::new(download_cache_tree, &*storage, chunk_size);
+    let open_directory = Arc::new(
+        OpenDirectory::create_directory(std::path::PathBuf::from("/"), storage.clone(), clock, 1)
+            .await
+            .unwrap(),
+    );
+    let empty_directory_reference = open_directory.latest_reference();
+    let dropbox_api = FailingDropboxApi {};
+    let importer = DropboxImporter::new(
+        storage.clone(),
+        &empty_directory_reference,
+        &dropbox_api,
+        &download_cache,
+    );
+    // TODO: expect an error to be reported
+    importer
+        .import_directory_entry(
+            "/",
+            &DropboxFolderEntry {
+                name: ">".to_string(),
+                kind: DropboxFolderEntryKind::Folder,
+            },
+            &open_directory,
+        )
+        .await
+        .unwrap();
+    assert_directory_contents(&open_directory, &BTreeMap::new()).await;
 }
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of files whose downloaded content does not match the expected Dropbox content hash.
  * Added validation for unsupported entry names and missing or invalid content hashes, preventing invalid entries from being imported.
  * Ensured failed imports do not leave files or download-cache entries behind.

* **Tests**
  * Expanded coverage for directory imports and download-cache behaviour across successful and failed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->