### PR TITLE
Upgrade sccache to 0.17.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
   # https://github.com/mozilla/sccache/blob/main/docs/GHA.md
   SCCACHE_GHA_ENABLED: on
-  SCCACHE_VERSION: "v0.16.0"
-  SCCACHE_FILENAME: "sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz"
+  SCCACHE_VERSION: "v0.17.0"
+  SCCACHE_FILENAME: "sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
   RUSTC_WRAPPER: sccache
   RUST_BACKTRACE: 1
 

--- a/scripts/install_sccache.sh
+++ b/scripts/install_sccache.sh
@@ -10,5 +10,5 @@ if which sccache >/dev/null 2>&1; then
 else
     echo "sccache is not in the PATH, trying to install it."
     export CARGO_LOG=info
-    cargo --verbose install --locked sccache --version 0.16.0 || exit 1
+    cargo --verbose install --locked sccache --version 0.17.0 || exit 1
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled sccache tooling to version 0.17.0.
  * Ensured automated builds and local installation scripts use the same updated version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->